### PR TITLE
Fix outdate number error of findRepeatNumber

### DIFF
--- a/lcof/面试题03. 数组中重复的数字/README.md
+++ b/lcof/面试题03. 数组中重复的数字/README.md
@@ -35,7 +35,8 @@ class Solution:
                 if num == nums[num]:
                     return num
                 nums[i], nums[num] = nums[num], nums[i]
-
+                num = nums[i]
+        return -1
 ```
 
 ### **Java**


### PR DESCRIPTION
原方法忘记在交换后更新当前`i`指针对应的`num`，导致测试用例 `nums = [1, 3, 4, 0, 2, 5, 3]` 返回`1`（应该返回`3`）:
```
from typing import List

def findRepeatNumber(nums: List[int]) -> int:
    for i, num in enumerate(nums):
        while i != num:
            if num == nums[num]:
                return num
            nums[i], nums[num] = nums[num], nums[i]
           # 原方法缺少这一行：
           # num = nums[i]
    return -1

nums = [1, 3, 4, 0, 2, 5, 3]
findRepeatNumber(nums)
```
因此，本次提交作出了修正：
```
def findRepeatNumber(nums: List[int]) -> int:
    for i, num in enumerate(nums):
        while i != num:
            if num == nums[num]:
                return num
            nums[i], nums[num] = nums[num], nums[i]
            num = nums[i]
    return -1
```
修正后可通过三种边界测试和其他笔者想到的任何符合题目要求情况：
```
nums = [1, 3, 4, 0, 2, 5, 3] # should return 3
nums = [2, 4, 1, 0, 2, 5, 3] # should return 2
nums = [2, 4, 1, 0, 6, 5, 3] # should return -1
findRepeatNumber(nums)
```
另，虽然复杂度相同，但读者更偏爱只使用一个循环表示该过程：
```
def findRepeatNumber(nums: List[int]) -> int:
    i = 0
    while i < len(nums):
        print(nums)
        if nums[i] == i:
            i += 1
            continue
        if nums[nums[i]] == nums[i]: return nums[i]
        nums[nums[i]], nums[i] = nums[i], nums[nums[i]]
    return -1

nums = [1, 3, 4, 0, 2, 5, 3]
findRepeatNumber(nums)
```