### PR TITLE
fix: remove duplicate insertion to visited set

### DIFF
--- a/solution/2600-2699/2662.Minimum Cost of a Path With Special Roads/README.md
+++ b/solution/2600-2699/2662.Minimum Cost of a Path With Special Roads/README.md
@@ -92,7 +92,6 @@ class Solution:
                 continue
             vis.add((x, y))
             ans = min(ans, d + dist(x, y, *target))
-            vis.add((x, y))
             for x1, y1, x2, y2, cost in specialRoads:
                 heappush(q, (d + dist(x, y, x1, y1) + cost, x2, y2))
         return ans

--- a/solution/2600-2699/2662.Minimum Cost of a Path With Special Roads/README_EN.md
+++ b/solution/2600-2699/2662.Minimum Cost of a Path With Special Roads/README_EN.md
@@ -86,7 +86,6 @@ class Solution:
                 continue
             vis.add((x, y))
             ans = min(ans, d + dist(x, y, *target))
-            vis.add((x, y))
             for x1, y1, x2, y2, cost in specialRoads:
                 heappush(q, (d + dist(x, y, x1, y1) + cost, x2, y2))
         return ans

--- a/solution/2600-2699/2662.Minimum Cost of a Path With Special Roads/Solution.py
+++ b/solution/2600-2699/2662.Minimum Cost of a Path With Special Roads/Solution.py
@@ -14,7 +14,6 @@ class Solution:
                 continue
             vis.add((x, y))
             ans = min(ans, d + dist(x, y, *target))
-            vis.add((x, y))
             for x1, y1, x2, y2, cost in specialRoads:
                 heappush(q, (d + dist(x, y, x1, y1) + cost, x2, y2))
         return ans


### PR DESCRIPTION
There is a subtle mistake in the _Python3_ version of the algorithm: the point `(x, y)` is inserted into the _visited_ (`vis`) set twice.
The implementation and both versions of the documentation are corrected in this pull request.
> [!note]
> This isn't really a bug, as the algorithm itself remains correct :laughing: .

I've also submitted the modified solution to _LeetCode_, and it successfully passed all the tests!
![image](https://github.com/doocs/leetcode/assets/52515370/84906f0f-b2d6-48b1-9462-9c14f24c399c)

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.


### Description

copilot:summary

### Explanation of Changes

copilot:walkthrough

-->