### PR TITLE
chore: add `EditorConfig` configuration file `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# REF: https://spec.editorconfig.org/#supported-pairs
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+# tab_width = 4
+# end_of_line = lf
+charset = utf-8
+# spelling_language = en-US
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{md}]
+trim_trailing_whitespace = false
+
+[*.{go}]
+indent_style = tab
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 npx lint-staged --allow-empty $1


### PR DESCRIPTION
添加 [EditorConfig](https://editorconfig.org/) 的配置文件 [`.editorconfig`](https://spec.editorconfig.org/) 以在不同的编辑器和集成开发环境中保持一致的编码风格。
Add the [`.editorconfig`](https://spec.editorconfig.org/) configuration file for [EditorConfig](https://editorconfig.org/) to maintain a consistent coding style across different editors and IDEs.