### PR TITLE
fix: remove unused lines of no.354

### DIFF
--- a/solution/0300-0399/0354.Russian Doll Envelopes/README.md
+++ b/solution/0300-0399/0354.Russian Doll Envelopes/README.md
@@ -76,8 +76,6 @@ class Solution:
                 d.append(h)
             else:
                 idx = bisect_left(d, h)
-                if idx == len(d):
-                    idx = 0
                 d[idx] = h
         return len(d)
 ```

--- a/solution/0300-0399/0354.Russian Doll Envelopes/README_EN.md
+++ b/solution/0300-0399/0354.Russian Doll Envelopes/README_EN.md
@@ -74,8 +74,6 @@ class Solution:
                 d.append(h)
             else:
                 idx = bisect_left(d, h)
-                if idx == len(d):
-                    idx = 0
                 d[idx] = h
         return len(d)
 ```

--- a/solution/0300-0399/0354.Russian Doll Envelopes/Solution.py
+++ b/solution/0300-0399/0354.Russian Doll Envelopes/Solution.py
@@ -7,7 +7,5 @@ class Solution:
                 d.append(h)
             else:
                 idx = bisect_left(d, h)
-                if idx == len(d):
-                    idx = 0
                 d[idx] = h
         return len(d)


### PR DESCRIPTION
Remove confusing and unecessary lines.

Since h is not bigger than the last element in the d array, it is not possible that bisect_left(d, h) will return the index that is equal to the length of the array d. The maximum value of the return value is len(d)-1.

I also tested it in the leetcode and it works.


