### PR TITLE
feat: add solutions to lc problem: No.4013

### DIFF
--- a/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/README.md
+++ b/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/README.md
@@ -189,32 +189,316 @@ edit_url: https://github.com/doocs/leetcode/edit/main/solution/4000-4099/4013.Co
 
 <!-- solution:start -->
 
-### 方法一
+### 方法一：前缀和 + 树状数组
+
+对于一个子数组，设其中偶数元素的个数为 $x$，奇数元素的个数为 $y$。题目要求 $y > 0$ 且 $\frac{x}{y} \le \frac{a}{b}$。由于 $b > 0$，$y > 0$，该不等式等价于 $a \cdot y - b \cdot x \ge 0$。
+
+而当 $y = 0$ 时，由于子数组非空，必然有 $x > 0$，此时 $a \cdot y - b \cdot x = -b \cdot x < 0$，上述不等式不成立。因此，题目中的两个条件可以合并为一个：$a \cdot y - b \cdot x \ge 0$。
+
+我们把 $\textit{nums}$ 中的奇数视作 $a$，偶数视作 $-b$，得到数组 $\textit{arr}$，那么原问题等价于：统计 $\textit{arr}$ 中有多少个元素和 $\ge 0$ 的非空连续子数组。
+
+设 $\textit{arr}$ 的前缀和数组为 $s$，则子数组 $[L, R - 1]$ 的元素和等于 $s[R] - s[L]$，问题进一步转化为：有多少个下标对 $(L, R)$ 满足 $0 \le L < R \le n$ 且 $s[R] - s[L] \ge 0$，即 $s[L] \le s[R]$？
+
+我们枚举 $R$，需要快速统计 $R$ 左边满足 $s[L] \le s[R]$ 的 $L$ 的个数。这可以用树状数组来维护：先对 $s$ 中的所有值进行离散化（排序去重），然后从左到右遍历 $s$。对于每个值 $v = s[R]$，我们在树状数组中查询已经插入且不大于 $v$ 的元素个数，将其累加到答案中，然后把 $v$ 插入树状数组。
+
+时间复杂度 $O(n \times \log n)$，空间复杂度 $O(n)$。其中 $n$ 是数组 $\textit{nums}$ 的长度。
 
 <!-- tabs:start -->
 
 #### Python3
 
 ```python
+class BinaryIndexedTree:
+    __slots__ = "n", "c"
 
+    def __init__(self, n: int):
+        self.n = n
+        self.c = [0] * (n + 1)
+
+    def update(self, x: int, delta: int) -> None:
+        while x <= self.n:
+            self.c[x] += delta
+            x += x & -x
+
+    def query(self, x: int) -> int:
+        s = 0
+        while x:
+            s += self.c[x]
+            x -= x & -x
+        return s
+
+
+class Solution:
+    def countRatioSubarrays(self, nums: list[int], a: int, b: int) -> int:
+        n = len(nums)
+        s = [0] * (n + 1)
+        for i, x in enumerate(nums):
+            s[i + 1] = s[i] + (a if x % 2 else -b)
+
+        st = sorted(set(s))
+        bit = BinaryIndexedTree(len(st) + 1)
+        ans = 0
+        for v in s:
+            x = bisect_left(st, v) + 1
+            ans += bit.query(x)
+            bit.update(x, 1)
+        return ans
 ```
 
 #### Java
 
 ```java
+class BinaryIndexedTree {
+    private final int n;
+    private final int[] c;
 
+    public BinaryIndexedTree(int n) {
+        this.n = n;
+        this.c = new int[n + 1];
+    }
+
+    public void update(int x, int delta) {
+        while (x <= n) {
+            c[x] += delta;
+            x += x & -x;
+        }
+    }
+
+    public int query(int x) {
+        int s = 0;
+        while (x > 0) {
+            s += c[x];
+            x -= x & -x;
+        }
+        return s;
+    }
+}
+
+class Solution {
+    public long countRatioSubarrays(int[] nums, int a, int b) {
+        int n = nums.length;
+
+        long[] s = new long[n + 1];
+        for (int i = 0; i < n; i++) {
+            s[i + 1] = s[i] + (nums[i] % 2 == 1 ? a : -b);
+        }
+
+        long[] st = s.clone();
+        Arrays.sort(st);
+
+        int m = 0;
+        for (long x : st) {
+            if (m == 0 || st[m - 1] != x) {
+                st[m++] = x;
+            }
+        }
+
+        BinaryIndexedTree bit = new BinaryIndexedTree(m + 1);
+
+        long ans = 0;
+
+        for (long v : s) {
+            int x = Arrays.binarySearch(st, 0, m, v) + 1;
+            ans += bit.query(x);
+            bit.update(x, 1);
+        }
+
+        return ans;
+    }
+}
 ```
 
 #### C++
 
 ```cpp
+class BinaryIndexedTree {
+    int n;
+    vector<int> c;
 
+public:
+    BinaryIndexedTree(int n)
+        : n(n)
+        , c(n + 1) {}
+
+    void update(int x, int delta) {
+        while (x <= n) {
+            c[x] += delta;
+            x += x & -x;
+        }
+    }
+
+    int query(int x) {
+        int s = 0;
+        while (x > 0) {
+            s += c[x];
+            x -= x & -x;
+        }
+        return s;
+    }
+};
+
+class Solution {
+public:
+    long long countRatioSubarrays(vector<int>& nums, int a, int b) {
+        int n = nums.size();
+
+        vector<long long> s(n + 1);
+        for (int i = 0; i < n; i++) {
+            s[i + 1] = s[i] + (nums[i] % 2 ? a : -b);
+        }
+
+        vector<long long> st = s;
+        sort(st.begin(), st.end());
+        st.erase(unique(st.begin(), st.end()), st.end());
+
+        BinaryIndexedTree bit(st.size() + 1);
+
+        long long ans = 0;
+
+        for (long long v : s) {
+            int x = lower_bound(st.begin(), st.end(), v) - st.begin() + 1;
+            ans += bit.query(x);
+            bit.update(x, 1);
+        }
+
+        return ans;
+    }
+};
 ```
 
 #### Go
 
 ```go
+type BinaryIndexedTree struct {
+	n int
+	c []int
+}
 
+func NewBinaryIndexedTree(n int) *BinaryIndexedTree {
+	return &BinaryIndexedTree{
+		n: n,
+		c: make([]int, n+1),
+	}
+}
+
+func (bit *BinaryIndexedTree) update(x int, delta int) {
+	for x <= bit.n {
+		bit.c[x] += delta
+		x += x & -x
+	}
+}
+
+func (bit *BinaryIndexedTree) query(x int) int {
+	sum := 0
+	for x > 0 {
+		sum += bit.c[x]
+		x -= x & -x
+	}
+	return sum
+}
+
+func countRatioSubarrays(nums []int, a int, b int) int64 {
+	n := len(nums)
+
+	s := make([]int64, n+1)
+
+	for i, x := range nums {
+		if x%2 == 1 {
+			s[i+1] = s[i] + int64(a)
+		} else {
+			s[i+1] = s[i] - int64(b)
+		}
+	}
+
+	st := append([]int64{}, s...)
+	sort.Slice(st, func(i, j int) bool {
+		return st[i] < st[j]
+	})
+
+	uniq := make([]int64, 0, len(st))
+	for _, x := range st {
+		if len(uniq) == 0 || uniq[len(uniq)-1] != x {
+			uniq = append(uniq, x)
+		}
+	}
+
+	bit := NewBinaryIndexedTree(len(uniq) + 1)
+
+	var ans int64
+
+	for _, v := range s {
+		x := sort.Search(len(uniq), func(i int) bool {
+			return uniq[i] >= v
+		}) + 1
+
+		ans += int64(bit.query(x))
+		bit.update(x, 1)
+	}
+
+	return ans
+}
+```
+
+#### TypeScript
+
+```ts
+class BinaryIndexedTree {
+    private n: number;
+    private c: number[];
+
+    constructor(n: number) {
+        this.n = n;
+        this.c = new Array(n + 1).fill(0);
+    }
+
+    update(x: number, delta: number): void {
+        while (x <= this.n) {
+            this.c[x] += delta;
+            x += x & -x;
+        }
+    }
+
+    query(x: number): number {
+        let sum = 0;
+        while (x > 0) {
+            sum += this.c[x];
+            x -= x & -x;
+        }
+        return sum;
+    }
+}
+
+function countRatioSubarrays(nums: number[], a: number, b: number): number {
+    const n = nums.length;
+
+    const s = new Array<number>(n + 1).fill(0);
+
+    for (let i = 0; i < n; i++) {
+        s[i + 1] = s[i] + (nums[i] % 2 === 1 ? a : -b);
+    }
+
+    const st = [...s].sort((x, y) => x - y);
+
+    const uniq: number[] = [];
+    for (const x of st) {
+        if (uniq.length === 0 || uniq[uniq.length - 1] !== x) {
+            uniq.push(x);
+        }
+    }
+
+    const bit = new BinaryIndexedTree(uniq.length + 1);
+
+    let ans = 0;
+
+    for (const v of s) {
+        const x = _.sortedIndex(uniq, v) + 1;
+
+        ans += bit.query(x);
+        bit.update(x, 1);
+    }
+
+    return ans;
+}
 ```
 
 <!-- tabs:end -->

--- a/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/README.md
+++ b/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/README.md
@@ -191,9 +191,9 @@ edit_url: https://github.com/doocs/leetcode/edit/main/solution/4000-4099/4013.Co
 
 ### 方法一：前缀和 + 树状数组
 
-对于一个子数组，设其中偶数元素的个数为 $x$，奇数元素的个数为 $y$。题目要求 $y > 0$ 且 $\frac{x}{y} \le \frac{a}{b}$。由于 $b > 0$，$y > 0$，该不等式等价于 $a \cdot y - b \cdot x \ge 0$。
+对于一个子数组，设其中偶数元素的个数为 $x$，奇数元素的个数为 $y$。题目要求 $y > 0$ 且 $\frac{x}{y} \le \frac{a}{b}$。由于 $b > 0$, $y > 0$，该不等式等价于 $a \cdot y - b \cdot x \ge 0$。
 
-而当 $y = 0$ 时，由于子数组非空，必然有 $x > 0$，此时 $a \cdot y - b \cdot x = -b \cdot x < 0$，上述不等式不成立。因此，题目中的两个条件可以合并为一个：$a \cdot y - b \cdot x \ge 0$。
+而当 $y = 0$ 时，由于子数组非空，必然有 $x > 0$，此时 $a \cdot y - b \cdot x = -b \cdot x < 0$，上述不等式不成立。因此，题目中的两个条件可以合并为 $a \cdot y - b \cdot x \ge 0$。
 
 我们把 $\textit{nums}$ 中的奇数视作 $a$，偶数视作 $-b$，得到数组 $\textit{arr}$，那么原问题等价于：统计 $\textit{arr}$ 中有多少个元素和 $\ge 0$ 的非空连续子数组。
 

--- a/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/README_EN.md
+++ b/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/README_EN.md
@@ -187,32 +187,316 @@ edit_url: https://github.com/doocs/leetcode/edit/main/solution/4000-4099/4013.Co
 
 <!-- solution:start -->
 
-### Solution 1
+### Solution 1: Prefix Sum + Binary Indexed Tree
+
+For a subarray, let $x$ be the number of even elements and $y$ be the number of odd elements. The problem requires $y > 0$ and $\frac{x}{y} \le \frac{a}{b}$. Since $b > 0$ and $y > 0$, the inequality is equivalent to $a \cdot y - b \cdot x \ge 0$.
+
+When $y = 0$, since the subarray is non-empty, we must have $x > 0$. In this case, $a \cdot y - b \cdot x = -b \cdot x < 0$, so the inequality does not hold. Therefore, the two conditions in the problem can be merged into a single one: $a \cdot y - b \cdot x \ge 0$.
+
+We treat the odd numbers in $\textit{nums}$ as $a$ and the even numbers as $-b$, resulting in an array $\textit{arr}$. The original problem is then equivalent to counting the number of non-empty contiguous subarrays of $\textit{arr}$ whose element sum is at least $0$.
+
+Let $s$ be the prefix sum array of $\textit{arr}$. The element sum of the subarray $[L, R - 1]$ equals $s[R] - s[L]$, so the problem is further transformed into: how many index pairs $(L, R)$ satisfy $0 \le L < R \le n$ and $s[R] - s[L] \ge 0$, i.e., $s[L] \le s[R]$?
+
+We enumerate $R$ and need to quickly count the number of indices $L$ to the left of $R$ that satisfy $s[L] \le s[R]$. This can be maintained with a Binary Indexed Tree: we first discretize all values in $s$ (sort and deduplicate), then traverse $s$ from left to right. For each value $v = s[R]$, we query the number of inserted elements not greater than $v$ from the Binary Indexed Tree and add it to the answer, then insert $v$ into the tree.
+
+The time complexity is $O(n \times \log n)$, and the space complexity is $O(n)$, where $n$ is the length of the array $\textit{nums}$.
 
 <!-- tabs:start -->
 
 #### Python3
 
 ```python
+class BinaryIndexedTree:
+    __slots__ = "n", "c"
 
+    def __init__(self, n: int):
+        self.n = n
+        self.c = [0] * (n + 1)
+
+    def update(self, x: int, delta: int) -> None:
+        while x <= self.n:
+            self.c[x] += delta
+            x += x & -x
+
+    def query(self, x: int) -> int:
+        s = 0
+        while x:
+            s += self.c[x]
+            x -= x & -x
+        return s
+
+
+class Solution:
+    def countRatioSubarrays(self, nums: list[int], a: int, b: int) -> int:
+        n = len(nums)
+        s = [0] * (n + 1)
+        for i, x in enumerate(nums):
+            s[i + 1] = s[i] + (a if x % 2 else -b)
+
+        st = sorted(set(s))
+        bit = BinaryIndexedTree(len(st) + 1)
+        ans = 0
+        for v in s:
+            x = bisect_left(st, v) + 1
+            ans += bit.query(x)
+            bit.update(x, 1)
+        return ans
 ```
 
 #### Java
 
 ```java
+class BinaryIndexedTree {
+    private final int n;
+    private final int[] c;
 
+    public BinaryIndexedTree(int n) {
+        this.n = n;
+        this.c = new int[n + 1];
+    }
+
+    public void update(int x, int delta) {
+        while (x <= n) {
+            c[x] += delta;
+            x += x & -x;
+        }
+    }
+
+    public int query(int x) {
+        int s = 0;
+        while (x > 0) {
+            s += c[x];
+            x -= x & -x;
+        }
+        return s;
+    }
+}
+
+class Solution {
+    public long countRatioSubarrays(int[] nums, int a, int b) {
+        int n = nums.length;
+
+        long[] s = new long[n + 1];
+        for (int i = 0; i < n; i++) {
+            s[i + 1] = s[i] + (nums[i] % 2 == 1 ? a : -b);
+        }
+
+        long[] st = s.clone();
+        Arrays.sort(st);
+
+        int m = 0;
+        for (long x : st) {
+            if (m == 0 || st[m - 1] != x) {
+                st[m++] = x;
+            }
+        }
+
+        BinaryIndexedTree bit = new BinaryIndexedTree(m + 1);
+
+        long ans = 0;
+
+        for (long v : s) {
+            int x = Arrays.binarySearch(st, 0, m, v) + 1;
+            ans += bit.query(x);
+            bit.update(x, 1);
+        }
+
+        return ans;
+    }
+}
 ```
 
 #### C++
 
 ```cpp
+class BinaryIndexedTree {
+    int n;
+    vector<int> c;
 
+public:
+    BinaryIndexedTree(int n)
+        : n(n)
+        , c(n + 1) {}
+
+    void update(int x, int delta) {
+        while (x <= n) {
+            c[x] += delta;
+            x += x & -x;
+        }
+    }
+
+    int query(int x) {
+        int s = 0;
+        while (x > 0) {
+            s += c[x];
+            x -= x & -x;
+        }
+        return s;
+    }
+};
+
+class Solution {
+public:
+    long long countRatioSubarrays(vector<int>& nums, int a, int b) {
+        int n = nums.size();
+
+        vector<long long> s(n + 1);
+        for (int i = 0; i < n; i++) {
+            s[i + 1] = s[i] + (nums[i] % 2 ? a : -b);
+        }
+
+        vector<long long> st = s;
+        sort(st.begin(), st.end());
+        st.erase(unique(st.begin(), st.end()), st.end());
+
+        BinaryIndexedTree bit(st.size() + 1);
+
+        long long ans = 0;
+
+        for (long long v : s) {
+            int x = lower_bound(st.begin(), st.end(), v) - st.begin() + 1;
+            ans += bit.query(x);
+            bit.update(x, 1);
+        }
+
+        return ans;
+    }
+};
 ```
 
 #### Go
 
 ```go
+type BinaryIndexedTree struct {
+	n int
+	c []int
+}
 
+func NewBinaryIndexedTree(n int) *BinaryIndexedTree {
+	return &BinaryIndexedTree{
+		n: n,
+		c: make([]int, n+1),
+	}
+}
+
+func (bit *BinaryIndexedTree) update(x int, delta int) {
+	for x <= bit.n {
+		bit.c[x] += delta
+		x += x & -x
+	}
+}
+
+func (bit *BinaryIndexedTree) query(x int) int {
+	sum := 0
+	for x > 0 {
+		sum += bit.c[x]
+		x -= x & -x
+	}
+	return sum
+}
+
+func countRatioSubarrays(nums []int, a int, b int) int64 {
+	n := len(nums)
+
+	s := make([]int64, n+1)
+
+	for i, x := range nums {
+		if x%2 == 1 {
+			s[i+1] = s[i] + int64(a)
+		} else {
+			s[i+1] = s[i] - int64(b)
+		}
+	}
+
+	st := append([]int64{}, s...)
+	sort.Slice(st, func(i, j int) bool {
+		return st[i] < st[j]
+	})
+
+	uniq := make([]int64, 0, len(st))
+	for _, x := range st {
+		if len(uniq) == 0 || uniq[len(uniq)-1] != x {
+			uniq = append(uniq, x)
+		}
+	}
+
+	bit := NewBinaryIndexedTree(len(uniq) + 1)
+
+	var ans int64
+
+	for _, v := range s {
+		x := sort.Search(len(uniq), func(i int) bool {
+			return uniq[i] >= v
+		}) + 1
+
+		ans += int64(bit.query(x))
+		bit.update(x, 1)
+	}
+
+	return ans
+}
+```
+
+#### TypeScript
+
+```ts
+class BinaryIndexedTree {
+    private n: number;
+    private c: number[];
+
+    constructor(n: number) {
+        this.n = n;
+        this.c = new Array(n + 1).fill(0);
+    }
+
+    update(x: number, delta: number): void {
+        while (x <= this.n) {
+            this.c[x] += delta;
+            x += x & -x;
+        }
+    }
+
+    query(x: number): number {
+        let sum = 0;
+        while (x > 0) {
+            sum += this.c[x];
+            x -= x & -x;
+        }
+        return sum;
+    }
+}
+
+function countRatioSubarrays(nums: number[], a: number, b: number): number {
+    const n = nums.length;
+
+    const s = new Array<number>(n + 1).fill(0);
+
+    for (let i = 0; i < n; i++) {
+        s[i + 1] = s[i] + (nums[i] % 2 === 1 ? a : -b);
+    }
+
+    const st = [...s].sort((x, y) => x - y);
+
+    const uniq: number[] = [];
+    for (const x of st) {
+        if (uniq.length === 0 || uniq[uniq.length - 1] !== x) {
+            uniq.push(x);
+        }
+    }
+
+    const bit = new BinaryIndexedTree(uniq.length + 1);
+
+    let ans = 0;
+
+    for (const v of s) {
+        const x = _.sortedIndex(uniq, v) + 1;
+
+        ans += bit.query(x);
+        bit.update(x, 1);
+    }
+
+    return ans;
+}
 ```
 
 <!-- tabs:end -->

--- a/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/Solution.cpp
+++ b/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/Solution.cpp
@@ -1,0 +1,53 @@
+class BinaryIndexedTree {
+    int n;
+    vector<int> c;
+
+public:
+    BinaryIndexedTree(int n)
+        : n(n)
+        , c(n + 1) {}
+
+    void update(int x, int delta) {
+        while (x <= n) {
+            c[x] += delta;
+            x += x & -x;
+        }
+    }
+
+    int query(int x) {
+        int s = 0;
+        while (x > 0) {
+            s += c[x];
+            x -= x & -x;
+        }
+        return s;
+    }
+};
+
+class Solution {
+public:
+    long long countRatioSubarrays(vector<int>& nums, int a, int b) {
+        int n = nums.size();
+
+        vector<long long> s(n + 1);
+        for (int i = 0; i < n; i++) {
+            s[i + 1] = s[i] + (nums[i] % 2 ? a : -b);
+        }
+
+        vector<long long> st = s;
+        sort(st.begin(), st.end());
+        st.erase(unique(st.begin(), st.end()), st.end());
+
+        BinaryIndexedTree bit(st.size() + 1);
+
+        long long ans = 0;
+
+        for (long long v : s) {
+            int x = lower_bound(st.begin(), st.end(), v) - st.begin() + 1;
+            ans += bit.query(x);
+            bit.update(x, 1);
+        }
+
+        return ans;
+    }
+};

--- a/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/Solution.go
+++ b/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/Solution.go
@@ -1,0 +1,68 @@
+type BinaryIndexedTree struct {
+	n int
+	c []int
+}
+
+func NewBinaryIndexedTree(n int) *BinaryIndexedTree {
+	return &BinaryIndexedTree{
+		n: n,
+		c: make([]int, n+1),
+	}
+}
+
+func (bit *BinaryIndexedTree) update(x int, delta int) {
+	for x <= bit.n {
+		bit.c[x] += delta
+		x += x & -x
+	}
+}
+
+func (bit *BinaryIndexedTree) query(x int) int {
+	sum := 0
+	for x > 0 {
+		sum += bit.c[x]
+		x -= x & -x
+	}
+	return sum
+}
+
+func countRatioSubarrays(nums []int, a int, b int) int64 {
+	n := len(nums)
+
+	s := make([]int64, n+1)
+
+	for i, x := range nums {
+		if x%2 == 1 {
+			s[i+1] = s[i] + int64(a)
+		} else {
+			s[i+1] = s[i] - int64(b)
+		}
+	}
+
+	st := append([]int64{}, s...)
+	sort.Slice(st, func(i, j int) bool {
+		return st[i] < st[j]
+	})
+
+	uniq := make([]int64, 0, len(st))
+	for _, x := range st {
+		if len(uniq) == 0 || uniq[len(uniq)-1] != x {
+			uniq = append(uniq, x)
+		}
+	}
+
+	bit := NewBinaryIndexedTree(len(uniq) + 1)
+
+	var ans int64
+
+	for _, v := range s {
+		x := sort.Search(len(uniq), func(i int) bool {
+			return uniq[i] >= v
+		}) + 1
+
+		ans += int64(bit.query(x))
+		bit.update(x, 1)
+	}
+
+	return ans
+}

--- a/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/Solution.java
+++ b/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/Solution.java
@@ -1,0 +1,58 @@
+class BinaryIndexedTree {
+    private final int n;
+    private final int[] c;
+
+    public BinaryIndexedTree(int n) {
+        this.n = n;
+        this.c = new int[n + 1];
+    }
+
+    public void update(int x, int delta) {
+        while (x <= n) {
+            c[x] += delta;
+            x += x & -x;
+        }
+    }
+
+    public int query(int x) {
+        int s = 0;
+        while (x > 0) {
+            s += c[x];
+            x -= x & -x;
+        }
+        return s;
+    }
+}
+
+class Solution {
+    public long countRatioSubarrays(int[] nums, int a, int b) {
+        int n = nums.length;
+
+        long[] s = new long[n + 1];
+        for (int i = 0; i < n; i++) {
+            s[i + 1] = s[i] + (nums[i] % 2 == 1 ? a : -b);
+        }
+
+        long[] st = s.clone();
+        Arrays.sort(st);
+
+        int m = 0;
+        for (long x : st) {
+            if (m == 0 || st[m - 1] != x) {
+                st[m++] = x;
+            }
+        }
+
+        BinaryIndexedTree bit = new BinaryIndexedTree(m + 1);
+
+        long ans = 0;
+
+        for (long v : s) {
+            int x = Arrays.binarySearch(st, 0, m, v) + 1;
+            ans += bit.query(x);
+            bit.update(x, 1);
+        }
+
+        return ans;
+    }
+}

--- a/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/Solution.py
+++ b/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/Solution.py
@@ -1,0 +1,35 @@
+class BinaryIndexedTree:
+    __slots__ = "n", "c"
+
+    def __init__(self, n: int):
+        self.n = n
+        self.c = [0] * (n + 1)
+
+    def update(self, x: int, delta: int) -> None:
+        while x <= self.n:
+            self.c[x] += delta
+            x += x & -x
+
+    def query(self, x: int) -> int:
+        s = 0
+        while x:
+            s += self.c[x]
+            x -= x & -x
+        return s
+
+
+class Solution:
+    def countRatioSubarrays(self, nums: list[int], a: int, b: int) -> int:
+        n = len(nums)
+        s = [0] * (n + 1)
+        for i, x in enumerate(nums):
+            s[i + 1] = s[i] + (a if x % 2 else -b)
+
+        st = sorted(set(s))
+        bit = BinaryIndexedTree(len(st) + 1)
+        ans = 0
+        for v in s:
+            x = bisect_left(st, v) + 1
+            ans += bit.query(x)
+            bit.update(x, 1)
+        return ans

--- a/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/Solution.ts
+++ b/solution/4000-4099/4013.Count Subarrays With Even Odd Ratio II/Solution.ts
@@ -1,0 +1,57 @@
+class BinaryIndexedTree {
+    private n: number;
+    private c: number[];
+
+    constructor(n: number) {
+        this.n = n;
+        this.c = new Array(n + 1).fill(0);
+    }
+
+    update(x: number, delta: number): void {
+        while (x <= this.n) {
+            this.c[x] += delta;
+            x += x & -x;
+        }
+    }
+
+    query(x: number): number {
+        let sum = 0;
+        while (x > 0) {
+            sum += this.c[x];
+            x -= x & -x;
+        }
+        return sum;
+    }
+}
+
+function countRatioSubarrays(nums: number[], a: number, b: number): number {
+    const n = nums.length;
+
+    const s = new Array<number>(n + 1).fill(0);
+
+    for (let i = 0; i < n; i++) {
+        s[i + 1] = s[i] + (nums[i] % 2 === 1 ? a : -b);
+    }
+
+    const st = [...s].sort((x, y) => x - y);
+
+    const uniq: number[] = [];
+    for (const x of st) {
+        if (uniq.length === 0 || uniq[uniq.length - 1] !== x) {
+            uniq.push(x);
+        }
+    }
+
+    const bit = new BinaryIndexedTree(uniq.length + 1);
+
+    let ans = 0;
+
+    for (const v of s) {
+        const x = _.sortedIndex(uniq, v) + 1;
+
+        ans += bit.query(x);
+        bit.update(x, 1);
+    }
+
+    return ans;
+}


### PR DESCRIPTION
## Summary

- Add solutions for lc problem No.4013 (Count Subarrays With Even Odd Ratio II) in Python, Java, C++, Go, and TypeScript, formatted with black, clang-format, gofmt, and prettier
- Add Chinese and English solution descriptions: merge the two validity conditions into a * y - b * x >= 0, transform odds to a and evens to -b, then count index pairs (L, R) with s[L] <= s[R] over the prefix sum array using a Binary Indexed Tree with discretization

## Test plan

- [x] Verify black, clang-format, gofmt, and prettier checks all pass
- [x] Verify README code blocks match the formatted solution files
- [ ] Review the rendered README/README_EN on the docs site