### PR TITLE
docs: add sponsor section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@
 
 [English Version](/README_EN.md)
 
+## 赞助商
+
+<table>
+<tr>
+<td width="180"><a href="https://apinebula.ai/ref/lMbidCQZ"><img src="https://cdn-doocs.oss-cn-shenzhen.aliyuncs.com/gh/doocs/leetcode%40main/images/sponsor-apinebula.png" alt="APINEBULA" width="150"></a></td>
+<td>感谢 APINEBULA 赞助本项目！APINEBULA 是银河录像局旗下的企业级 AI 聚合平台，背靠大平台资源，面向开发者、团队与企业用户提供稳定、高性价比的大模型 API 接入服务。平台聚合 Claude、GPT、Gemini 等主流满血模型，一个接口，接入全球顶尖 AI 大模型，各大模型价格低至 1 折起，支持企业级高并发、正式合同、对公打款与开票服务，适合 AI 编程、Agent 开发、业务系统集成等多种场景！使用<a href="https://apinebula.ai/ref/lMbidCQZ">此链接</a>注册并在充值时填写 "leetcode" 优惠码可享九折优惠！</td>
+</tr>
+</table>
+
+> 想出现在这里？如有赞助意向，欢迎添加微信 **YLB0109**（备注「赞助」）联系洽谈。
+
 ## 站点
 
 <https://leetcode.doocs.org>

--- a/README_EN.md
+++ b/README_EN.md
@@ -17,6 +17,17 @@ This project contains solutions for problems from LeetCode, "Coding Interviews (
 
 [中文文档](/README.md)
 
+## Sponsor
+
+<table>
+<tr>
+<td width="180"><a href="https://apinebula.ai/ref/lMbidCQZ"><img src="https://cdn-doocs.oss-cn-shenzhen.aliyuncs.com/gh/doocs/leetcode%40main/images/sponsor-apinebula.png" alt="APINEBULA" width="150"></a></td>
+<td>Thanks to APINEBULA for sponsoring this project! APINEBULA, an enterprise-grade AI aggregation platform under Galaxy Video Bureau, leverages extensive platform resources to provide developers, teams, and enterprises with stable, cost-effective access to large language model APIs. The platform integrates leading, full-powered models like Claude, GPT, and Gemini, allowing you to connect to the world's top AI models through a single API, with prices starting as low as 10% of the original cost. Designed for AI programming, Agent development, and business system integration, APINEBULA supports enterprise-grade high concurrency, formal contracts, corporate bank transfers, and invoicing services. Register via <a href="https://apinebula.ai/ref/lMbidCQZ">this link</a> and enter the "leetcode" promo code when topping up to get 10% off!</td>
+</tr>
+</table>
+
+> Want to appear here? If you are interested in sponsoring this project, feel free to reach out via WeChat: **YLB0109** (please note "Sponsorship").
+
 ## Site
 
 https://leetcode.doocs.org/en


### PR DESCRIPTION
## Summary

- Add a **Sponsor** section to `README.md` and `README_EN.md`, placed right after the introduction
- Feature sponsor APINEBULA in a `<table>` layout (150px logo + description with referral link), following the style of farion1231/cc-switch so new sponsors can be appended as extra `<tr>` rows
- Add a "Want to appear here?" call-to-action below the table with WeChat contact (YLB0109) to invite more sponsors

## Test plan

- [x] Verify the sponsor section renders correctly on GitHub (logo, links, table layout)
- [x] Confirm `npx prettier --check README.md README_EN.md` passes (lint-staged hook also ran on commit)
- [ ] Check the EN translation reads naturally and the referral link/promo code "leetcode" work as expected
