### PR TITLE
feat: update solutions to lc problem: No.2958

### DIFF
--- a/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/README.md
+++ b/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/README.md
@@ -77,9 +77,9 @@ tags:
 
 ### 方法一：双指针
 
-我们可以用两个指针 $j$ 和 $i$ 分别表示子数组的左右端点，初始时两个指针都指向数组的第一个元素。
+我们可以用两个指针 $l$ 和 $r$ 分别表示子数组的左右端点，初始时两个指针都指向数组的第一个元素。
 
-接下来，我们遍历数组 $nums$ 中的每个元素 $x$，对于每个元素 $x$，我们将 $x$ 的出现次数加一，然后判断当前子数组是否满足要求。如果当前子数组不满足要求，我们就将指针 $j$ 右移一位，并将 $nums[j]$ 的出现次数减一，直到当前子数组满足要求为止。然后我们更新答案 $ans = \max(ans, i - j + 1)$。继续遍历，直到 $i$ 到达数组的末尾。
+接下来，我们遍历数组 $nums$ 中的每个元素 $x$，对于每个元素 $x$，我们将 $x$ 的出现次数加一，然后判断当前子数组是否满足要求。如果当前子数组不满足要求，我们就将指针 $l$ 右移一位，并将 $nums[l]$ 的出现次数减一，直到当前子数组满足要求为止。然后我们更新答案 $ans = \max(ans, r - l + 1)$。继续遍历，直到 $r$ 到达数组的末尾。
 
 时间复杂度 $O(n)$，空间复杂度 $O(n)$。其中 $n$ 是数组 $nums$ 的长度。
 
@@ -90,14 +90,14 @@ tags:
 ```python
 class Solution:
     def maxSubarrayLength(self, nums: List[int], k: int) -> int:
+        ans = l = 0
         cnt = defaultdict(int)
-        ans = j = 0
-        for i, x in enumerate(nums):
+        for r, x in enumerate(nums):
             cnt[x] += 1
             while cnt[x] > k:
-                cnt[nums[j]] -= 1
-                j += 1
-            ans = max(ans, i - j + 1)
+                cnt[nums[l]] -= 1
+                l += 1
+            ans = max(ans, r - l + 1)
         return ans
 ```
 
@@ -106,14 +106,14 @@ class Solution:
 ```java
 class Solution {
     public int maxSubarrayLength(int[] nums, int k) {
-        Map<Integer, Integer> cnt = new HashMap<>();
         int ans = 0;
-        for (int i = 0, j = 0; i < nums.length; ++i) {
-            cnt.merge(nums[i], 1, Integer::sum);
-            while (cnt.get(nums[i]) > k) {
-                cnt.merge(nums[j++], -1, Integer::sum);
+        Map<Integer, Integer> cnt = new HashMap<>();
+        for (int l = 0, r = 0; r < nums.length; ++r) {
+            cnt.merge(nums[r], 1, Integer::sum);
+            while (cnt.get(nums[r]) > k) {
+                cnt.merge(nums[l++], -1, Integer::sum);
             }
-            ans = Math.max(ans, i - j + 1);
+            ans = Math.max(ans, r - l + 1);
         }
         return ans;
     }
@@ -126,14 +126,14 @@ class Solution {
 class Solution {
 public:
     int maxSubarrayLength(vector<int>& nums, int k) {
-        unordered_map<int, int> cnt;
         int ans = 0;
-        for (int i = 0, j = 0; i < nums.size(); ++i) {
-            ++cnt[nums[i]];
-            while (cnt[nums[i]] > k) {
-                --cnt[nums[j++]];
+        unordered_map<int, int> cnt;
+        for (int l = 0, r = 0; r < nums.size(); ++r) {
+            ++cnt[nums[r]];
+            while (cnt[nums[r]] > k) {
+                --cnt[nums[l++]];
             }
-            ans = max(ans, i - j + 1);
+            ans = max(ans, r - l + 1);
         }
         return ans;
     }
@@ -144,13 +144,14 @@ public:
 
 ```go
 func maxSubarrayLength(nums []int, k int) (ans int) {
-	cnt := map[int]int{}
-	for i, j, n := 0, 0, len(nums); i < n; i++ {
-		cnt[nums[i]]++
-		for ; cnt[nums[i]] > k; j++ {
-			cnt[nums[j]]--
+	cnt := make(map[int]int)
+	for l, r := 0, 0; r < len(nums); r++ {
+		cnt[nums[r]]++
+		for cnt[nums[r]] > k {
+			cnt[nums[l]]--
+			l++
 		}
-		ans = max(ans, i-j+1)
+		ans = max(ans, r-l+1)
 	}
 	return
 }
@@ -160,16 +161,42 @@ func maxSubarrayLength(nums []int, k int) (ans int) {
 
 ```ts
 function maxSubarrayLength(nums: number[], k: number): number {
-    const cnt: Map<number, number> = new Map();
     let ans = 0;
-    for (let i = 0, j = 0; i < nums.length; ++i) {
-        cnt.set(nums[i], (cnt.get(nums[i]) ?? 0) + 1);
-        for (; cnt.get(nums[i])! > k; ++j) {
-            cnt.set(nums[j], cnt.get(nums[j])! - 1);
+    const cnt = new Map<number, number>();
+    for (let l = 0, r = 0; r < nums.length; ++r) {
+        cnt.set(nums[r], (cnt.get(nums[r]) ?? 0) + 1);
+        while (cnt.get(nums[r])! > k) {
+            cnt.set(nums[l], cnt.get(nums[l])! - 1);
+            ++l;
         }
-        ans = Math.max(ans, i - j + 1);
+        ans = Math.max(ans, r - l + 1);
     }
     return ans;
+}
+```
+
+#### Rust
+
+```rust
+impl Solution {
+    pub fn max_subarray_length(nums: Vec<i32>, k: i32) -> i32 {
+        let mut ans = 0;
+        let mut cnt = std::collections::HashMap::new();
+
+        let mut l = 0;
+        for r in 0..nums.len() {
+            *cnt.entry(nums[r]).or_insert(0) += 1;
+
+            while cnt[&nums[r]] > k {
+                *cnt.get_mut(&nums[l]).unwrap() -= 1;
+                l += 1;
+            }
+
+            ans = ans.max((r - l + 1) as i32);
+        }
+
+        ans
+    }
 }
 ```
 

--- a/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/README_EN.md
+++ b/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/README_EN.md
@@ -75,9 +75,9 @@ It can be shown that there are no good subarrays with length more than 4.
 
 ### Solution 1: Two Pointers
 
-We can use two pointers $j$ and $i$ to represent the left and right endpoints of the subarray, initially both pointers point to the first element of the array.
+We can use two pointers $l$ and $r$ to represent the left and right endpoints of the subarray, initially both pointers point to the first element of the array.
 
-Next, we iterate over each element $x$ in the array $nums$. For each element $x$, we increment the occurrence count of $x$, then check if the current subarray meets the requirements. If the current subarray does not meet the requirements, we move the pointer $j$ one step to the right, and decrement the occurrence count of $nums[j]$, until the current subarray meets the requirements. Then we update the answer $ans = \max(ans, i - j + 1)$. Continue the iteration until $i$ reaches the end of the array.
+Next, we iterate over each element $x$ in the array $nums$. For each element $x$, we increment the occurrence count of $x$, then check if the current subarray meets the requirements. If the current subarray does not meet the requirements, we move the pointer $l$ one step to the right, and decrement the occurrence count of $nums[l]$, until the current subarray meets the requirements. Then we update the answer $ans = \max(ans, r - l + 1)$. Continue the iteration until $r$ reaches the end of the array.
 
 The time complexity is $O(n)$, and the space complexity is $O(n)$. Here, $n$ is the length of the array $nums$.
 
@@ -88,14 +88,14 @@ The time complexity is $O(n)$, and the space complexity is $O(n)$. Here, $n$ is 
 ```python
 class Solution:
     def maxSubarrayLength(self, nums: List[int], k: int) -> int:
+        ans = l = 0
         cnt = defaultdict(int)
-        ans = j = 0
-        for i, x in enumerate(nums):
+        for r, x in enumerate(nums):
             cnt[x] += 1
             while cnt[x] > k:
-                cnt[nums[j]] -= 1
-                j += 1
-            ans = max(ans, i - j + 1)
+                cnt[nums[l]] -= 1
+                l += 1
+            ans = max(ans, r - l + 1)
         return ans
 ```
 
@@ -104,14 +104,14 @@ class Solution:
 ```java
 class Solution {
     public int maxSubarrayLength(int[] nums, int k) {
-        Map<Integer, Integer> cnt = new HashMap<>();
         int ans = 0;
-        for (int i = 0, j = 0; i < nums.length; ++i) {
-            cnt.merge(nums[i], 1, Integer::sum);
-            while (cnt.get(nums[i]) > k) {
-                cnt.merge(nums[j++], -1, Integer::sum);
+        Map<Integer, Integer> cnt = new HashMap<>();
+        for (int l = 0, r = 0; r < nums.length; ++r) {
+            cnt.merge(nums[r], 1, Integer::sum);
+            while (cnt.get(nums[r]) > k) {
+                cnt.merge(nums[l++], -1, Integer::sum);
             }
-            ans = Math.max(ans, i - j + 1);
+            ans = Math.max(ans, r - l + 1);
         }
         return ans;
     }
@@ -124,14 +124,14 @@ class Solution {
 class Solution {
 public:
     int maxSubarrayLength(vector<int>& nums, int k) {
-        unordered_map<int, int> cnt;
         int ans = 0;
-        for (int i = 0, j = 0; i < nums.size(); ++i) {
-            ++cnt[nums[i]];
-            while (cnt[nums[i]] > k) {
-                --cnt[nums[j++]];
+        unordered_map<int, int> cnt;
+        for (int l = 0, r = 0; r < nums.size(); ++r) {
+            ++cnt[nums[r]];
+            while (cnt[nums[r]] > k) {
+                --cnt[nums[l++]];
             }
-            ans = max(ans, i - j + 1);
+            ans = max(ans, r - l + 1);
         }
         return ans;
     }
@@ -142,13 +142,14 @@ public:
 
 ```go
 func maxSubarrayLength(nums []int, k int) (ans int) {
-	cnt := map[int]int{}
-	for i, j, n := 0, 0, len(nums); i < n; i++ {
-		cnt[nums[i]]++
-		for ; cnt[nums[i]] > k; j++ {
-			cnt[nums[j]]--
+	cnt := make(map[int]int)
+	for l, r := 0, 0; r < len(nums); r++ {
+		cnt[nums[r]]++
+		for cnt[nums[r]] > k {
+			cnt[nums[l]]--
+			l++
 		}
-		ans = max(ans, i-j+1)
+		ans = max(ans, r-l+1)
 	}
 	return
 }
@@ -158,16 +159,42 @@ func maxSubarrayLength(nums []int, k int) (ans int) {
 
 ```ts
 function maxSubarrayLength(nums: number[], k: number): number {
-    const cnt: Map<number, number> = new Map();
     let ans = 0;
-    for (let i = 0, j = 0; i < nums.length; ++i) {
-        cnt.set(nums[i], (cnt.get(nums[i]) ?? 0) + 1);
-        for (; cnt.get(nums[i])! > k; ++j) {
-            cnt.set(nums[j], cnt.get(nums[j])! - 1);
+    const cnt = new Map<number, number>();
+    for (let l = 0, r = 0; r < nums.length; ++r) {
+        cnt.set(nums[r], (cnt.get(nums[r]) ?? 0) + 1);
+        while (cnt.get(nums[r])! > k) {
+            cnt.set(nums[l], cnt.get(nums[l])! - 1);
+            ++l;
         }
-        ans = Math.max(ans, i - j + 1);
+        ans = Math.max(ans, r - l + 1);
     }
     return ans;
+}
+```
+
+#### Rust
+
+```rust
+impl Solution {
+    pub fn max_subarray_length(nums: Vec<i32>, k: i32) -> i32 {
+        let mut ans = 0;
+        let mut cnt = std::collections::HashMap::new();
+
+        let mut l = 0;
+        for r in 0..nums.len() {
+            *cnt.entry(nums[r]).or_insert(0) += 1;
+
+            while cnt[&nums[r]] > k {
+                *cnt.get_mut(&nums[l]).unwrap() -= 1;
+                l += 1;
+            }
+
+            ans = ans.max((r - l + 1) as i32);
+        }
+
+        ans
+    }
 }
 ```
 

--- a/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/Solution.cpp
+++ b/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/Solution.cpp
@@ -1,14 +1,14 @@
 class Solution {
 public:
     int maxSubarrayLength(vector<int>& nums, int k) {
-        unordered_map<int, int> cnt;
         int ans = 0;
-        for (int i = 0, j = 0; i < nums.size(); ++i) {
-            ++cnt[nums[i]];
-            while (cnt[nums[i]] > k) {
-                --cnt[nums[j++]];
+        unordered_map<int, int> cnt;
+        for (int l = 0, r = 0; r < nums.size(); ++r) {
+            ++cnt[nums[r]];
+            while (cnt[nums[r]] > k) {
+                --cnt[nums[l++]];
             }
-            ans = max(ans, i - j + 1);
+            ans = max(ans, r - l + 1);
         }
         return ans;
     }

--- a/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/Solution.go
+++ b/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/Solution.go
@@ -1,11 +1,12 @@
 func maxSubarrayLength(nums []int, k int) (ans int) {
-	cnt := map[int]int{}
-	for i, j, n := 0, 0, len(nums); i < n; i++ {
-		cnt[nums[i]]++
-		for ; cnt[nums[i]] > k; j++ {
-			cnt[nums[j]]--
+	cnt := make(map[int]int)
+	for l, r := 0, 0; r < len(nums); r++ {
+		cnt[nums[r]]++
+		for cnt[nums[r]] > k {
+			cnt[nums[l]]--
+			l++
 		}
-		ans = max(ans, i-j+1)
+		ans = max(ans, r-l+1)
 	}
 	return
 }

--- a/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/Solution.java
+++ b/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/Solution.java
@@ -1,13 +1,13 @@
 class Solution {
     public int maxSubarrayLength(int[] nums, int k) {
-        Map<Integer, Integer> cnt = new HashMap<>();
         int ans = 0;
-        for (int i = 0, j = 0; i < nums.length; ++i) {
-            cnt.merge(nums[i], 1, Integer::sum);
-            while (cnt.get(nums[i]) > k) {
-                cnt.merge(nums[j++], -1, Integer::sum);
+        Map<Integer, Integer> cnt = new HashMap<>();
+        for (int l = 0, r = 0; r < nums.length; ++r) {
+            cnt.merge(nums[r], 1, Integer::sum);
+            while (cnt.get(nums[r]) > k) {
+                cnt.merge(nums[l++], -1, Integer::sum);
             }
-            ans = Math.max(ans, i - j + 1);
+            ans = Math.max(ans, r - l + 1);
         }
         return ans;
     }

--- a/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/Solution.py
+++ b/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/Solution.py
@@ -1,11 +1,11 @@
 class Solution:
     def maxSubarrayLength(self, nums: List[int], k: int) -> int:
+        ans = l = 0
         cnt = defaultdict(int)
-        ans = j = 0
-        for i, x in enumerate(nums):
+        for r, x in enumerate(nums):
             cnt[x] += 1
             while cnt[x] > k:
-                cnt[nums[j]] -= 1
-                j += 1
-            ans = max(ans, i - j + 1)
+                cnt[nums[l]] -= 1
+                l += 1
+            ans = max(ans, r - l + 1)
         return ans

--- a/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/Solution.rs
+++ b/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/Solution.rs
@@ -1,0 +1,20 @@
+impl Solution {
+    pub fn max_subarray_length(nums: Vec<i32>, k: i32) -> i32 {
+        let mut ans = 0;
+        let mut cnt = std::collections::HashMap::new();
+
+        let mut l = 0;
+        for r in 0..nums.len() {
+            *cnt.entry(nums[r]).or_insert(0) += 1;
+
+            while cnt[&nums[r]] > k {
+                *cnt.get_mut(&nums[l]).unwrap() -= 1;
+                l += 1;
+            }
+
+            ans = ans.max((r - l + 1) as i32);
+        }
+
+        ans
+    }
+}

--- a/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/Solution.ts
+++ b/solution/2900-2999/2958.Length of Longest Subarray With at Most K Frequency/Solution.ts
@@ -1,12 +1,13 @@
 function maxSubarrayLength(nums: number[], k: number): number {
-    const cnt: Map<number, number> = new Map();
     let ans = 0;
-    for (let i = 0, j = 0; i < nums.length; ++i) {
-        cnt.set(nums[i], (cnt.get(nums[i]) ?? 0) + 1);
-        for (; cnt.get(nums[i])! > k; ++j) {
-            cnt.set(nums[j], cnt.get(nums[j])! - 1);
+    const cnt = new Map<number, number>();
+    for (let l = 0, r = 0; r < nums.length; ++r) {
+        cnt.set(nums[r], (cnt.get(nums[r]) ?? 0) + 1);
+        while (cnt.get(nums[r])! > k) {
+            cnt.set(nums[l], cnt.get(nums[l])! - 1);
+            ++l;
         }
-        ans = Math.max(ans, i - j + 1);
+        ans = Math.max(ans, r - l + 1);
     }
     return ans;
 }


### PR DESCRIPTION
## Summary
- Update solutions for No.2958 Length of Longest Subarray With at Most K Frequency: rewrite implementations (Python/Java/C++/Go/TypeScript) with cleaner two-pointer naming (l/r) and add a new Rust solution
- Sync README.md and README_EN.md code blocks, add Rust tab, and update the Chinese/English solution descriptions to match the new implementations

## Test plan
- [x] Format all sources (black / clang-format / gofmt / prettier / rustfmt)
- [x] lint-staged pre-commit hooks pass
- [ ] CI checks pass