### PR TITLE
fix: update contest Guardian and Knight rating cutoffs

### DIFF
--- a/solution/CONTEST_README.md
+++ b/solution/CONTEST_README.md
@@ -14,11 +14,20 @@ comments: true
 
 | 段位 | 比例 | 段位名   | 国服分数线  | 勋章                                                                                                                    |
 | ---- | ---- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
-| LV3  | 5%   | Guardian | &ge;2278.34 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Guardian.gif" style="width: 80px;" /></p> |
-| LV2  | 20%  | Knight   | &ge;1889.36 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Knight.gif" style="width: 80px;" /></p>   |
+| LV3  | 5%   | Guardian | &ge;2270.49 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Guardian.gif" style="width: 80px;" /></p> |
+| LV2  | 20%  | Knight   | &ge;1888.66 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Knight.gif" style="width: 80px;" /></p>   |
 | LV1  | 75%  | -        | -           | -                                                                                                                       |
 
 力扣竞赛 **全国排名前 10** 的用户，全站用户名展示为品牌橙色。
+
+当前分数线对应的守门员，以及最接近但未达到该分数线的用户如下（统计范围为竞赛积分 &ge;1600 的 42342 名用户）：
+
+| 段位     | 角色   | 全国排名 | 分数    | 用户                                                                   |
+| -------- | ------ | -------- | ------- | ---------------------------------------------------------------------- |
+| Guardian | 守门员 | 2117     | 2270.49 | [yuan-zhi-b](https://leetcode.cn/u/yuan-zhi-b/)                         |
+| Guardian | 差一线 | 2118     | 2270.39 | [biubiu0919](https://leetcode.cn/u/biubiu0919/)                         |
+| Knight   | 守门员 | 10585    | 1888.66 | [lin-jie-4](https://leetcode.cn/u/lin-jie-4/)                           |
+| Knight   | 差一线 | 10586    | 1888.65 | [xi-you-fu-su-4](https://leetcode.cn/u/xi-you-fu-su-4/)                 |
 
 ## 赛后估分网站
 

--- a/solution/CONTEST_README_EN.md
+++ b/solution/CONTEST_README_EN.md
@@ -17,11 +17,20 @@ If you are in the top 25% of the contest rating, you’ll get the “Knight” b
 
 | Level | Proportion | Badge    | Rating      |                                                                                                                         |
 | ----- | ---------- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
-| LV3   | 5\%        | Guardian | &ge;2228.90 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Guardian.gif" style="width: 80px;" /></p> |
-| LV2   | 20\%       | Knight   | &ge;1842.73 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Knight.gif" style="width: 80px;" /></p>   |
+| LV3   | 5\%        | Guardian | &ge;2123.78 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Guardian.gif" style="width: 80px;" /></p> |
+| LV2   | 20\%       | Knight   | &ge;1854.07 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Knight.gif" style="width: 80px;" /></p>   |
 | LV1   | 75\%       | -        | -           | -                                                                                                                       |
 
 For top 10 users (excluding LCCN users), your LeetCode ID will be colored orange on the ranking board. You'll also have the honor with you when you post/comment under discuss.
+
+The global ranking includes LCCN users, so the cutoffs below follow the Guardian / Knight contest badges actually shown on leetcode.com (not a raw 5% / 25% split of the mixed global list).
+
+| Badge    | Role        | Global Rank | Rating   | User                                                                 |
+| -------- | ----------- | ----------- | -------- | -------------------------------------------------------------------- |
+| Guardian | Gatekeeper  | 11714       | 2123.781 | [tdkkdt](https://leetcode.com/u/tdkkdt/)                             |
+| Guardian | Just below  | 11715       | 2123.780 | [ARUNMOZHICHELVAN](https://leetcode.com/u/ARUNMOZHICHELVAN/)         |
+| Knight   | Gatekeeper  | 53687       | 1854.066 | [yugg_007](https://leetcode.com/u/yugg_007/)                         |
+| Knight   | Just below  | 53688       | 1854.065 | [gsupe02](https://leetcode.com/u/gsupe02/)                           |
 
 ## Rating Predictor
 

--- a/solution/rating.py
+++ b/solution/rating.py
@@ -1,164 +1,449 @@
-from string import Template
+"""Fetch Guardian / Knight contest rating cutoffs.
+
+CN (leetcode.cn)
+    Local ranking is CN-only. The cutoff is the rating of the last user in the
+    top 5% / 25% among users with rating >= 1600.
+
+US (leetcode.com)
+    Global ranking mixes LCCN accounts. A raw 5% / 25% split of that list does
+    not match the badges shown on leetcode.com. The cutoff is the rating of the
+    last .com user who actually holds the Guardian / Knight contest badge.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterator, List, Optional
 
 import requests
 import urllib3
 
 urllib3.disable_warnings()
 
+RATING_CUTOFF = 1600
+GUARDIAN_RATIO = 0.05
+KNIGHT_RATIO = 0.25
+PAGE_SIZE_FALLBACK = 25
+RETRY = 3
+TIMEOUT = 20
+USER_AGENT = (
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) '
+    'Chrome/77.0.3865.120 Safari/537.36'
+)
+# Guardian > Knight > none. Used so a Guardian still counts as "at least Knight".
+BADGE_TIER = {'Guardian': 2, 'Knight': 1}
 
-class Ranking:
-    def __init__(self, region='CN', retry=3):
-        self.retry = retry
-        self.region = region
-        if region == 'CN':
-            self.url = 'https://leetcode.cn/graphql'
-            self.page_query = Template(
-                "{\n  localRankingV2(page:$page) {\nmyRank {\nattendedContestCount\n"
-                "currentRatingRanking\ndataRegion\nisDeleted\nuser {\nrealName\n"
-                "userAvatar\nuserSlug\n__typename\n}\n__typename\n}\npage\ntotalUsers\n"
-                "userPerPage\nrankingNodes {\nattendedContestCount\ncurrentRatingRanking\n"
-                "dataRegion\nisDeleted\nuser {\nrealName\nuserAvatar\nuserSlug\n__typename\n}\n__"
-                "typename\n}\n__typename\n  }\n}\n"
-            )
+CN_RANKING_QUERY = (
+    '{{ localRankingV2(page:{page}) {{ page totalUsers userPerPage '
+    'rankingNodes {{ currentRatingRanking currentRating user {{ userSlug }} }} }} }}'
+)
+US_RANKING_QUERY = (
+    '{{ globalRanking(page:{page}) {{ totalUsers userPerPage rankingNodes {{ '
+    'currentGlobalRanking currentRating dataRegion user {{ username }} }} }} }}'
+)
+US_BADGE_QUERY = (
+    'query userContestRankingInfo($username: String!) { '
+    'userContestRanking(username: $username) { badge { name } } }'
+)
+CN_WARMUP_QUERY = {
+    'operationName': 'questionData',
+    'variables': {'titleSlug': 'two-sum'},
+    'query': (
+        'query questionData($titleSlug: String!) { '
+        'question(titleSlug: $titleSlug) { questionFrontendId titleSlug } }'
+    ),
+}
+
+
+@dataclass(frozen=True)
+class User:
+    rank: int
+    rating: float
+    uid: str
+    region: str = ''
+
+
+@dataclass(frozen=True)
+class Cutoff:
+    badge: str
+    gatekeeper: User
+    just_below: Optional[User]
+    just_below_badge: str = ''
+
+
+@dataclass(frozen=True)
+class Site:
+    key: str
+    origin: str
+    ranking_field: str
+    ranking_query: str
+    cookie_attr: str
+    warmup: bool
+    use_badges: bool
+
+
+SITES = {
+    'CN': Site(
+        key='CN',
+        origin='https://leetcode.cn',
+        ranking_field='localRankingV2',
+        ranking_query=CN_RANKING_QUERY,
+        cookie_attr='cn',
+        warmup=True,
+        use_badges=False,
+    ),
+    'US': Site(
+        key='US',
+        origin='https://leetcode.com',
+        ranking_field='globalRanking',
+        ranking_query=US_RANKING_QUERY,
+        cookie_attr='en',
+        warmup=False,
+        use_badges=True,
+    ),
+}
+
+
+def load_cookies() -> Dict[str, str]:
+    cookies = {'cn': '', 'en': ''}
+    env_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), '.env')
+    if not os.path.exists(env_file):
+        return cookies
+    with open(env_file, encoding='utf-8') as f:
+        for line in f:
+            if line.startswith('COOKIE_CN'):
+                cookies['cn'] = '='.join(line.split('=')[1:]).strip().strip('"')
+            elif line.startswith('COOKIE_EN'):
+                cookies['en'] = '='.join(line.split('=')[1:]).strip().strip('"')
+    return cookies
+
+
+def csrf_from_cookie(cookie: str) -> str:
+    m = re.search(r'(?:^|;\s*)csrftoken=([^;]+)', cookie)
+    return m.group(1) if m else ''
+
+
+def holds_badge(name: Optional[str], badge: str) -> bool:
+    return BADGE_TIER.get(name or '', 0) >= BADGE_TIER[badge]
+
+
+def last_true(lo: int, hi: int, pred: Callable[[int], bool]) -> int:
+    """Largest x in [lo, hi] such that pred(x) is True. pred must be prefix-true."""
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if pred(mid):
+            lo = mid
         else:
-            self.url = 'https://leetcode.com/graphql'
-            self.page_query = Template(
-                "{\nglobalRanking(page:$page){\ntotalUsers\nuserPerPage\nmyRank{\nranking\n"
-                "currentGlobalRanking\ncurrentRating\ndataRegion\nuser{\nnameColor\nactiveBadge{\n"
-                "displayName\nicon\n__typename\n}\n__typename\n}\n__typename\n}\nrankingNodes{\n"
-                "ranking\ncurrentRating\ncurrentGlobalRanking\ndataRegion\nuser{\nusername\nnameColor\n"
-                "activeBadge{\ndisplayName\nicon\n__typename\n}\nprofile{\nuserAvatar\ncountryCode\n"
-                "countryName\nrealName\n__typename\n}\n__typename\n}\n__typename\n}\n__typename\n}\n}\n"
-            )
+            hi = mid - 1
+    return lo
 
-    def load_page(self, page):
-        query = self.page_query.substitute(page=page)
-        for _ in range(self.retry):
-            resp = requests.post(url=self.url, json={'query': query}, verify=False)
-            if resp.status_code != 200:
-                continue
-            nodes = resp.json()['data'][
-                'localRankingV2' if self.region == 'CN' else 'globalRanking'
-            ]['rankingNodes']
-            if self.region == 'CN':
-                return [
-                    (int(v['currentRatingRanking']), v['user']['userSlug'])
-                    for v in nodes
-                ]
-            else:
-                return [
-                    (int(v['currentGlobalRanking']), v['user']['username'])
-                    for v in nodes
-                ]
-        return []
 
-    def _user_ranking(self, region, uid):
-        if region == 'CN':
-            key = 'userSlug'
-            url = 'https://leetcode.cn/graphql/noj-go/'
-            query = (
-                "\nquery userContestRankingInfo($userSlug:String!){\nuserContestRanking"
-                "(userSlug:$userSlug){\nattendedContestsCount\nrating\nglobalRanking\nlocalRanking\n"
-                "globalTotalParticipants\nlocalTotalParticipants\ntopPercentage\n}\n"
-                "userContestRankingHistory(userSlug:$userSlug){\nattended\ntotalProblems\n"
-                "trendingDirection\nfinishTimeInSeconds\nrating\nscore\nranking\ncontest{\n"
-                "title\ntitleCn\nstartTime\n}\n}\n}\n"
-            )
-        else:
-            key = 'username'
-            url = 'https://leetcode.com/graphql'
-            query = (
-                "\nquery userContestRankingInfo($username:String!){\nuserContestRanking"
-                "(username:$username){\nattendedContestsCount\nrating\nglobalRanking\n"
-                "totalParticipants\ntopPercentage\nbadge{\nname\n}\n}\nuserContestRankingHistory"
-                "(username:$username){\nattended\ntrendDirection\nproblemsSolved\n"
-                "totalProblems\nfinishTimeInSeconds\nrating\nranking\ncontest{\n"
-                "title\nstartTime\n}\n}\n}\n "
-            )
+class GraphQL:
+    def __init__(self, origin: str, cookie: str):
+        self.origin = origin
+        self.session = requests.Session()
+        self.session.verify = False
+        headers = {
+            'User-Agent': USER_AGENT,
+            'Connection': 'keep-alive',
+            'Content-Type': 'application/json',
+            'Referer': origin + '/contest/',
+            'Origin': origin,
+        }
+        if cookie:
+            headers['cookie'] = cookie
+            csrf = csrf_from_cookie(cookie)
+            if csrf:
+                headers['x-csrftoken'] = csrf
+                headers['x-requested-with'] = 'XMLHttpRequest'
+        self.session.headers.update(headers)
 
-        variables = {key: uid}
-        for _ in range(self.retry):
-            resp = requests.post(
-                url=url, json={'query': query, 'variables': variables}, verify=False
-            )
-            if resp.status_code != 200:
-                continue
-            res = resp.json()
-            if 'errors' in res:
-                break
-            ranking = res['data']['userContestRanking']
-            if ranking and 'rating' in ranking:
-                score = float(ranking['rating'])
-                if 'localRanking' in ranking:
-                    return int(ranking['localRanking']), score
-                if 'globalRanking' in ranking:
-                    return int(ranking['globalRanking']), score
-            return None, None
-
-    def get_user_ranking(self, uid):
-        for region in ['CN', 'US']:
-            # 美国站会有国服用户，这里最多需要查询两次
-            ranking, score = self._user_ranking(region, uid)
-            if score is not None:
-                return ranking, score
+    def post(
+        self, url: str, payload: dict, retries: int = RETRY, quiet: bool = False
+    ) -> Optional[dict]:
+        last_err: object = None
+        for attempt in range(retries):
+            try:
+                resp = self.session.post(url, json=payload, timeout=TIMEOUT)
+                if resp.status_code != 200:
+                    last_err = f'HTTP {resp.status_code}'
+                    time.sleep(min(8, 2**attempt))
+                    continue
+                try:
+                    data = resp.json()
+                except ValueError:
+                    last_err = 'non-JSON (possible WAF challenge)'
+                    time.sleep(min(8, 2**attempt))
+                    continue
+                if data.get('errors'):
+                    last_err = data['errors']
+                    time.sleep(1)
+                    continue
+                return data
+            except Exception as e:
+                last_err = e
+                time.sleep(min(8, 2**attempt))
+        if not quiet:
+            print(f'GraphQL 请求失败 {url}: {last_err}')
         return None
 
-    def get_1600_count(self):
-        left, right = 1, 4000
-        while left < right:
-            mid = (left + right + 1) >> 1
-            page = self.load_page(mid)
-            print(f'第 {mid} 页：', page)
-            if not page:
-                return 0
-            ranking, score = self.get_user_ranking(page[0][1])
-            if score >= 1600:
-                left = mid
-            else:
-                right = mid - 1
-        page = [uid for _, uid in self.load_page(left) if uid]
-        print('校准中...')
-        left, right = 0, len(page) - 1
-        while left < right:
-            mid = (left + right + 1) >> 1
-            ranking, score = self.get_user_ranking(page[mid])
-            if score >= 1600:
-                left = mid
-            else:
-                right = mid - 1
-        return self.get_user_ranking(page[left])[0]
 
-    def get_user(self, rank):
-        p = (rank - 1) // 25 + 1
-        offset = (rank - 1) % 25
-        page = self.load_page(p)
-        _, score = self.get_user_ranking(page[offset][1])
-        return score, page[offset][1]
+class Ranking:
+    def __init__(self, site: Site, cookies: Dict[str, str]):
+        self.site = site
+        self.graphql = GraphQL(site.origin, cookies[site.cookie_attr])
+        self.ranking_url = site.origin + '/graphql'
+        self.total_users = 0
+        self.user_per_page = PAGE_SIZE_FALLBACK
+        self._pages: Dict[int, List[User]] = {}
+        self._badges: Dict[str, Optional[str]] = {}
+        if site.warmup:
+            # leetcode.cn WAF often blocks the first ranking query unless a
+            # normal GraphQL request has already succeeded on this session.
+            for _ in range(5):
+                if self.graphql.post(
+                    self.ranking_url, CN_WARMUP_QUERY, retries=2, quiet=True
+                ):
+                    break
+                time.sleep(2)
 
-    def fetch_ranking_data(self):
-        total = self.get_1600_count()
+    def load_page(self, page: int) -> List[User]:
+        if page in self._pages:
+            return self._pages[page]
+        payload = {'query': self.site.ranking_query.format(page=page)}
+        data = self.graphql.post(self.ranking_url, payload)
+        if not data or not data.get('data'):
+            print(f'[{self.site.key}] 加载第 {page} 页失败')
+            return []
+        body = data['data'].get(self.site.ranking_field) or {}
+        self.total_users = int(body.get('totalUsers') or self.total_users)
+        self.user_per_page = int(
+            body.get('userPerPage') or self.user_per_page or PAGE_SIZE_FALLBACK
+        )
+        users: List[User] = []
+        for node in body.get('rankingNodes') or []:
+            parsed = self._parse_node(node)
+            if parsed:
+                users.append(parsed)
+        self._pages[page] = users
+        return users
+
+    def _parse_node(self, node: dict) -> Optional[User]:
+        user = node.get('user') or {}
+        if self.site.key == 'CN':
+            uid = user.get('userSlug')
+            rank = node.get('currentRatingRanking')
+        else:
+            uid = user.get('username')
+            rank = node.get('currentGlobalRanking')
+        rating = node.get('currentRating')
+        if not uid or rank is None or rating is None:
+            return None
+        return User(
+            rank=int(rank),
+            rating=float(rating),
+            uid=uid,
+            region=node.get('dataRegion') or '',
+        )
+
+    def user_at(self, rank: int) -> Optional[User]:
+        if rank < 1:
+            return None
+        page_no = (rank - 1) // self.user_per_page + 1
+        offset = (rank - 1) % self.user_per_page
+        users = self.load_page(page_no)
+        if offset >= len(users):
+            return None
+        return users[offset]
+
+    def count_rating_ge(self, cutoff: float = RATING_CUTOFF) -> int:
+        first = self.load_page(1)
+        if not first:
+            return 0
+        total_pages = max(
+            1, (self.total_users + self.user_per_page - 1) // self.user_per_page
+        )
+
+        def page_still_ge(page_no: int) -> bool:
+            users = self.load_page(page_no)
+            print(
+                f'[{self.site.key}] 第 {page_no} 页',
+                users[:1],
+                f'(共 {len(users)} 条)',
+            )
+            return bool(users) and users[0].rating >= cutoff
+
+        page_no = last_true(1, total_pages, page_still_ge)
+        users = self.load_page(page_no)
+        if not users:
+            return 0
+        idx = last_true(0, len(users) - 1, lambda i: users[i].rating >= cutoff)
+        if users[idx].rating < cutoff:
+            return 0
+        return users[idx].rank
+
+    def contest_badge(self, uid: str) -> Optional[str]:
+        """None = no .com contest profile; '' = profile exists but no contest badge."""
+        if uid in self._badges:
+            return self._badges[uid]
+        data = self.graphql.post(
+            self.ranking_url,
+            {'query': US_BADGE_QUERY, 'variables': {'username': uid}},
+        )
+        if not data:
+            self._badges[uid] = None
+            return None
+        ranking = (data.get('data') or {}).get('userContestRanking')
+        if ranking is None:
+            self._badges[uid] = None
+            return None
+        badge = (ranking.get('badge') or {}).get('name') or ''
+        self._badges[uid] = badge
+        return badge
+
+    def _evaluable_us(self, rank: int) -> Optional[User]:
+        user = self.user_at(rank)
+        if not user or user.region == 'CN':
+            return None
+        if self.contest_badge(user.uid) is None:
+            return None
+        return user
+
+    def _nearby_ranks(self, mid: int, lo: int, hi: int) -> Iterator[int]:
+        yield mid
+        for d in range(1, self.user_per_page + 1):
+            if mid - d >= lo:
+                yield mid - d
+            if mid + d <= hi:
+                yield mid + d
+
+    def last_us_with_badge(self, lo: int, hi: int, badge: str) -> Optional[User]:
+        ans = None
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            found = None
+            for rank in self._nearby_ranks(mid, lo, hi):
+                user = self._evaluable_us(rank)
+                if user:
+                    found = user
+                    break
+            if found is None:
+                break
+            name = self.contest_badge(found.uid)
+            print(
+                f'[{self.site.key}] rank {found.rank}: {found.uid} '
+                f'{found.rating:.3f} badge={name!r}'
+            )
+            if holds_badge(name, badge):
+                ans = found
+                lo = found.rank + 1
+            else:
+                hi = found.rank - 1
+        return ans
+
+    def next_evaluable_us(self, start: int, limit: int = 40) -> Optional[User]:
+        for rank in range(start, start + limit):
+            user = self._evaluable_us(rank)
+            if user:
+                return user
+        return None
+
+    def percentile_cutoffs(self, total: int) -> List[Cutoff]:
+        result = []
+        for badge, ratio in (('Guardian', GUARDIAN_RATIO), ('Knight', KNIGHT_RATIO)):
+            last_rank = max(1, int(total * ratio))
+            gatekeeper = self.user_at(last_rank)
+            if not gatekeeper:
+                continue
+            result.append(
+                Cutoff(
+                    badge=badge,
+                    gatekeeper=gatekeeper,
+                    just_below=self.user_at(last_rank + 1),
+                )
+            )
+        return result
+
+    def badge_cutoffs(self, total: int) -> List[Cutoff]:
+        result = []
+        for badge, ratio in (('Guardian', GUARDIAN_RATIO), ('Knight', KNIGHT_RATIO)):
+            lo = max(1, int(total * ratio * 0.8))
+            hi = min(total, int(total * ratio * 1.3))
+            gatekeeper = self.last_us_with_badge(lo, hi, badge)
+            if not gatekeeper:
+                continue
+            just_below = self.next_evaluable_us(gatekeeper.rank + 1)
+            below_badge = ''
+            if just_below:
+                below_badge = self.contest_badge(just_below.uid) or ''
+            result.append(
+                Cutoff(
+                    badge=badge,
+                    gatekeeper=gatekeeper,
+                    just_below=just_below,
+                    just_below_badge=below_badge,
+                )
+            )
+        return result
+
+    def fetch_cutoffs(self) -> Optional[List[Cutoff]]:
+        total = self.count_rating_ge()
         if not total:
-            return
-        print(f'[{self.region}] 1600 分以上共计 {total} 人')
+            print(f'[{self.site.key}] 未能获取 {RATING_CUTOFF} 分以上人数')
+            return None
+        print(f'[{self.site.key}] {RATING_CUTOFF} 分以上共计 {total} 人')
+        if self.site.use_badges:
+            return self.badge_cutoffs(total)
+        return self.percentile_cutoffs(total)
 
-        guardian = int(total * 0.05)
-        knight = int(total * 0.25)
-        g_first, g_last = self.get_user(1), self.get_user(guardian)
+
+def print_cutoffs(site_key: str, cutoffs: List[Cutoff]) -> None:
+    print(f'\n[{site_key}] 分数线')
+    for item in cutoffs:
+        g = item.gatekeeper
         print(
-            f'Guardian(top 5%): 共 {guardian} 名，守门员 {g_last[0]} 分（uid: {g_last[1]}），最高 {g_first[0]} 分（uid: {g_first[1]}）'
+            f'  {item.badge:<9} 守门员  rank={g.rank:<6} rating={g.rating:.3f}  {g.uid}'
         )
-        k_first, k_last = self.get_user(guardian + 1), self.get_user(knight)
+        b = item.just_below
+        if not b:
+            continue
+        note = f'  badge={item.just_below_badge!r}' if site_key == 'US' else ''
         print(
-            f'Knight(top 25%): 共 {knight} 名，守门员 {k_last[0]} 分（uid: {k_last[1]}），最高 {k_first[0]} 分（uid: {k_first[1]}）'
+            f'  {item.badge:<9} 差一线  rank={b.rank:<6} rating={b.rating:.3f}  {b.uid}{note}'
         )
 
 
-# 国服竞赛排名
-lk = Ranking(region='CN')
-lk.fetch_ranking_data()
+def run(region: str) -> Dict[str, List[Cutoff]]:
+    cookies = load_cookies()
+    keys = ['CN', 'US'] if region == 'all' else [region]
+    out: Dict[str, List[Cutoff]] = {}
+    for i, key in enumerate(keys):
+        if i:
+            print('\n------------------------------\n')
+        ranking = Ranking(SITES[key], cookies)
+        cutoffs = ranking.fetch_cutoffs()
+        if cutoffs:
+            print_cutoffs(key, cutoffs)
+            out[key] = cutoffs
+    return out
 
-print('\n------------------------------\n')
 
-# 全球竞赛排名
-gk = Ranking(region='US')
-gk.fetch_ranking_data()
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Fetch Guardian / Knight rating cutoffs'
+    )
+    parser.add_argument('--region', choices=['CN', 'US', 'all'], default='all')
+    args = parser.parse_args()
+    results = run(args.region)
+    print('\nREADME 分数线（守门员分数，四舍五入到两位）：')
+    for key, cutoffs in results.items():
+        parts = [
+            f'{item.badge} >= {round(item.gatekeeper.rating, 2):.2f}'
+            for item in cutoffs
+        ]
+        label = '国服' if key == 'CN' else '全球'
+        print(f'  {label}  ' + '，'.join(parts))

--- a/solution/template.md
+++ b/solution/template.md
@@ -138,11 +138,20 @@ This work is licensed under a <a rel="license" href="http://creativecommons.org/
 
 | 段位 | 比例 | 段位名   | 国服分数线  | 勋章                                                                                                                    |
 | ---- | ---- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
-| LV3  | 5%   | Guardian | &ge;2278.34 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Guardian.gif" style="width: 80px;" /></p> |
-| LV2  | 20%  | Knight   | &ge;1889.36 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Knight.gif" style="width: 80px;" /></p>   |
+| LV3  | 5%   | Guardian | &ge;2270.49 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Guardian.gif" style="width: 80px;" /></p> |
+| LV2  | 20%  | Knight   | &ge;1888.66 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Knight.gif" style="width: 80px;" /></p>   |
 | LV1  | 75%  | -        | -           | -                                                                                                                       |
 
 力扣竞赛 **全国排名前 10** 的用户，全站用户名展示为品牌橙色。
+
+当前分数线对应的守门员，以及最接近但未达到该分数线的用户如下（统计范围为竞赛积分 &ge;1600 的 42342 名用户）：
+
+| 段位     | 角色   | 全国排名 | 分数    | 用户                                                    |
+| -------- | ------ | -------- | ------- | ------------------------------------------------------- |
+| Guardian | 守门员 | 2117     | 2270.49 | [yuan-zhi-b](https://leetcode.cn/u/yuan-zhi-b/)         |
+| Guardian | 差一线 | 2118     | 2270.39 | [biubiu0919](https://leetcode.cn/u/biubiu0919/)         |
+| Knight   | 守门员 | 10585    | 1888.66 | [lin-jie-4](https://leetcode.cn/u/lin-jie-4/)           |
+| Knight   | 差一线 | 10586    | 1888.65 | [xi-you-fu-su-4](https://leetcode.cn/u/xi-you-fu-su-4/) |
 
 ## 赛后估分网站
 
@@ -175,11 +184,20 @@ If you are in the top 25% of the contest rating, you’ll get the “Knight” b
 
 | Level | Proportion | Badge    | Rating      |                                                                                                                         |
 | ----- | ---------- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
-| LV3   | 5\%        | Guardian | &ge;2228.90 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Guardian.gif" style="width: 80px;" /></p> |
-| LV2   | 20\%       | Knight   | &ge;1842.73 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Knight.gif" style="width: 80px;" /></p>   |
+| LV3   | 5\%        | Guardian | &ge;2123.78 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Guardian.gif" style="width: 80px;" /></p> |
+| LV2   | 20\%       | Knight   | &ge;1854.07 | <p><img alt="" src="https://fastly.jsdelivr.net/gh/doocs/leetcode@main/images/Knight.gif" style="width: 80px;" /></p>   |
 | LV1   | 75\%       | -        | -           | -                                                                                                                       |
 
 For top 10 users (excluding LCCN users), your LeetCode ID will be colored orange on the ranking board. You'll also have the honor with you when you post/comment under discuss.
+
+The global ranking includes LCCN users, so the cutoffs below follow the Guardian / Knight contest badges actually shown on leetcode.com (not a raw 5% / 25% split of the mixed global list).
+
+| Badge    | Role       | Global Rank | Rating   | User                                                         |
+| -------- | ---------- | ----------- | -------- | ------------------------------------------------------------ |
+| Guardian | Gatekeeper | 11714       | 2123.781 | [tdkkdt](https://leetcode.com/u/tdkkdt/)                     |
+| Guardian | Just below | 11715       | 2123.780 | [ARUNMOZHICHELVAN](https://leetcode.com/u/ARUNMOZHICHELVAN/) |
+| Knight   | Gatekeeper | 53687       | 1854.066 | [yugg_007](https://leetcode.com/u/yugg_007/)                 |
+| Knight   | Just below | 53688       | 1854.065 | [gsupe02](https://leetcode.com/u/gsupe02/)                   |
 
 ## Rating Predictor
 


### PR DESCRIPTION
﻿## Summary
- Refresh Guardian / Knight rating cutoffs in contest READMEs (CN and global).
- Rebuild `rating.py`: CN uses local ranking 5%/25%; leetcode.com uses actual contest badges because the global list includes LCCN users.
- Record gatekeepers and the closest users just below each cutoff.

## Test plan
- [x] `py rating.py --region US` matches leetcode.com Guardian/Knight badges (tdkkdt / yugg_007).
- [x] CN cutoffs taken from local ranking percentiles (verified against leetcode.cn profiles earlier).
- [ ] Re-run `py rating.py --region CN` after refreshing `COOKIE_CN` if Cloudflare blocks GraphQL.
