### PR TITLE
chore: bump pnpm to 10.34.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     "*.py": "py -m black -S",
     "*.rs": "rustfmt"
   },
-  "packageManager": "pnpm@10.25.0"
+  "packageManager": "pnpm@10.34.5"
 }


### PR DESCRIPTION
## Summary
- Bump `packageManager` to `pnpm@10.34.5` now that the Prettier workflow reads the version from `package.json`.

## Test plan
- [ ] Prettier workflow on this PR

Made with [Cursor](https://cursor.com)