### PR TITLE
feat: add C# and Rust solutions to lc problem: No.3876

### DIFF
--- a/solution/3800-3899/3876.Construct Uniform Parity Array II/README.md
+++ b/solution/3800-3899/3876.Construct Uniform Parity Array II/README.md
@@ -104,21 +104,19 @@ tags:
 
 时间复杂度 $O(n)$，其中 $n$ 是数组 $\textit{nums1}$ 的长度。空间复杂度 $O(1)$。
 
+相似题目：
+
+- [3875. 构造奇偶一致的数组 I](https://github.com/doocs/leetcode/blob/main/solution/3800-3899/3875.Construct%20Uniform%20Parity%20Array%20I/README.md)
+
 <!-- tabs:start -->
 
 #### Python3
 
 ```python
 class Solution:
-    def uniformArray(self, nums1: list[int]) -> bool:
-        mn = inf
-        for x in nums1:
-            if x % 2:
-                mn = min(mn, x)
-        for x in nums1:
-            if x % 2 == 0 and mn != inf and x < mn:
-                return False
-        return True
+    def uniformArray(self, nums1: List[int]) -> bool:
+        mn = min((x for x in nums1 if x & 1), default=None)
+        return mn is None or all(x >= mn for x in nums1 if x & 1 == 0)
 ```
 
 #### Java
@@ -200,6 +198,43 @@ function uniformArray(nums1: number[]): boolean {
         }
     }
     return true;
+}
+```
+
+#### Rust
+
+```rust
+impl Solution {
+    pub fn uniform_array(nums1: Vec<i32>) -> bool {
+        match nums1.iter().filter(|&&x| x % 2 == 1).min() {
+            None => true,
+            Some(&mn) => !nums1.iter().any(|&x| x % 2 == 0 && x < mn),
+        }
+    }
+}
+```
+
+#### C#
+
+```cs
+public class Solution {
+    public bool UniformArray(int[] nums1) {
+        int mn = int.MaxValue;
+        foreach (int x in nums1) {
+            if (x % 2 == 1) {
+                mn = Math.Min(mn, x);
+            }
+        }
+        if (mn == int.MaxValue) {
+            return true;
+        }
+        foreach (int x in nums1) {
+            if (x % 2 == 0 && x < mn) {
+                return false;
+            }
+        }
+        return true;
+    }
 }
 ```
 

--- a/solution/3800-3899/3876.Construct Uniform Parity Array II/README_EN.md
+++ b/solution/3800-3899/3876.Construct Uniform Parity Array II/README_EN.md
@@ -101,21 +101,19 @@ If $\textit{nums1}$ contains both odd and even numbers, we need to find the mini
 
 The time complexity is $O(n)$, where $n$ is the length of the array $\textit{nums1}$. The space complexity is $O(1)$.
 
+Similar problems:
+
+- [3875. Construct Uniform Parity Array I](https://github.com/doocs/leetcode/blob/main/solution/3800-3899/3875.Construct%20Uniform%20Parity%20Array%20I/README_EN.md)
+
 <!-- tabs:start -->
 
 #### Python3
 
 ```python
 class Solution:
-    def uniformArray(self, nums1: list[int]) -> bool:
-        mn = inf
-        for x in nums1:
-            if x % 2:
-                mn = min(mn, x)
-        for x in nums1:
-            if x % 2 == 0 and mn != inf and x < mn:
-                return False
-        return True
+    def uniformArray(self, nums1: List[int]) -> bool:
+        mn = min((x for x in nums1 if x & 1), default=None)
+        return mn is None or all(x >= mn for x in nums1 if x & 1 == 0)
 ```
 
 #### Java
@@ -197,6 +195,43 @@ function uniformArray(nums1: number[]): boolean {
         }
     }
     return true;
+}
+```
+
+#### Rust
+
+```rust
+impl Solution {
+    pub fn uniform_array(nums1: Vec<i32>) -> bool {
+        match nums1.iter().filter(|&&x| x % 2 == 1).min() {
+            None => true,
+            Some(&mn) => !nums1.iter().any(|&x| x % 2 == 0 && x < mn),
+        }
+    }
+}
+```
+
+#### C#
+
+```cs
+public class Solution {
+    public bool UniformArray(int[] nums1) {
+        int mn = int.MaxValue;
+        foreach (int x in nums1) {
+            if (x % 2 == 1) {
+                mn = Math.Min(mn, x);
+            }
+        }
+        if (mn == int.MaxValue) {
+            return true;
+        }
+        foreach (int x in nums1) {
+            if (x % 2 == 0 && x < mn) {
+                return false;
+            }
+        }
+        return true;
+    }
 }
 ```
 

--- a/solution/3800-3899/3876.Construct Uniform Parity Array II/Solution.cs
+++ b/solution/3800-3899/3876.Construct Uniform Parity Array II/Solution.cs
@@ -1,0 +1,19 @@
+public class Solution {
+    public bool UniformArray(int[] nums1) {
+        int mn = int.MaxValue;
+        foreach (int x in nums1) {
+            if (x % 2 == 1) {
+                mn = Math.Min(mn, x);
+            }
+        }
+        if (mn == int.MaxValue) {
+            return true;
+        }
+        foreach (int x in nums1) {
+            if (x % 2 == 0 && x < mn) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/solution/3800-3899/3876.Construct Uniform Parity Array II/Solution.py
+++ b/solution/3800-3899/3876.Construct Uniform Parity Array II/Solution.py
@@ -1,10 +1,4 @@
 class Solution:
-    def uniformArray(self, nums1: list[int]) -> bool:
-        mn = inf
-        for x in nums1:
-            if x % 2:
-                mn = min(mn, x)
-        for x in nums1:
-            if x % 2 == 0 and mn != inf and x < mn:
-                return False
-        return True
+    def uniformArray(self, nums1: List[int]) -> bool:
+        mn = min((x for x in nums1 if x & 1), default=None)
+        return mn is None or all(x >= mn for x in nums1 if x & 1 == 0)

--- a/solution/3800-3899/3876.Construct Uniform Parity Array II/Solution.rs
+++ b/solution/3800-3899/3876.Construct Uniform Parity Array II/Solution.rs
@@ -1,0 +1,8 @@
+impl Solution {
+    pub fn uniform_array(nums1: Vec<i32>) -> bool {
+        match nums1.iter().filter(|&&x| x % 2 == 1).min() {
+            None => true,
+            Some(&mn) => !nums1.iter().any(|&x| x % 2 == 0 && x < mn),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add C# and Rust solutions for LeetCode 3876 (Construct Uniform Parity Array II).
- Sync the Python implementation and bilingual READMEs to the same one-pass min-odd check.

## Test plan
- [x] Examples: `[1,4,7]` true, `[2,3]` false, `[4,6]` true
- [x] All-even / all-odd / even smaller than min odd
- [x] black, rustfmt, prettier
