### PR TITLE
perf: group LeetCode nav by range and enable prune

### DIFF
--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -1,0 +1,20 @@
+name: trigger-deploy
+
+on:
+  push:
+    branches:
+      - docs
+    paths-ignore:
+      - .git-committers-cache.json
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch deploy workflow on main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run deploy.yml --ref main --repo "${{ github.repository }}"

--- a/hooks/committer.py
+++ b/hooks/committer.py
@@ -157,14 +157,6 @@ class CommitterPlugin:
         self.cache_path.write_text(json.dumps(out, ensure_ascii=False, indent=2))
         _log(f"Saved committer cache: {len(self.page_authors)} entries -> {self.cache_path}")
 
-        _log("========= Committer Summary =========")
-        for k, v in sorted(self.page_authors.items()):
-            rt = v.get("retrieved", "N/A")
-            if isinstance(rt, int):
-                rt = datetime.fromtimestamp(rt, tz=timezone.utc).isoformat()
-            _log(f"[SUMMARY] {k}  |  retrieved: {rt}")
-        _log("=====================================")
-
     def on_page_context(self, context, page, cfg, nav):
         if not page.edit_url or _exclude(page.file.src_path, []):
             return context

--- a/hooks/stay_on_page.py
+++ b/hooks/stay_on_page.py
@@ -1,34 +1,30 @@
 import re
-from bs4 import BeautifulSoup
+
+_HREFLANG_HREF = re.compile(
+    r'(<a\b(?=[^>]*\bhreflang="(?P<lang>zh|en)")[^>]*\bhref=")[^"]*(")',
+    re.IGNORECASE,
+)
 
 
 def on_post_page(output, page, config):
+    if not output:
+        return output
+
+    rel = (page.url or "").lstrip("/")
+    cn_url = f"/{rel}" if rel else "/"
+    en_url = f"/en/{rel}" if rel else "/en/"
+    prefix = rel.split("/", 1)[0] if rel else ""
+    support_en = prefix not in ("lcof", "lcof2")
+
+    def repl(match):
+        lang = match.group("lang").lower()
+        href = en_url if lang == "en" and support_en else cn_url
+        if lang == "en" and not support_en:
+            return match.group(0)
+        return f"{match.group(1)}{href}{match.group(3)}"
+
     try:
-        if not output:
-            return output
-
-        soup = BeautifulSoup(output, "html.parser")
-
-        url = page.abs_url
-        if not url:
-            return output
-
-        cn_url = url.replace("/en/", "/")
-        en_url = "/en" + cn_url
-        support_en_lang = not cn_url.startswith("/lcof") and not cn_url.startswith("/lcof2")
-
-        # Update Chinese link
-        zh_link = soup.find("a", attrs={"hreflang": "zh"})
-        if zh_link:
-            zh_link["href"] = cn_url
-
-        # Update English link
-        if support_en_lang:
-            en_link = soup.find("a", attrs={"hreflang": "en"})
-            if en_link:
-                en_link["href"] = en_url
-
-        return str(soup)
+        return _HREFLANG_HREF.sub(repl, output)
     except Exception as e:
         print(f"Error in stay_on_page hook: {e}")
         return output

--- a/hooks/stay_on_page.py
+++ b/hooks/stay_on_page.py
@@ -1,7 +1,7 @@
 import re
 
 _HREFLANG_HREF = re.compile(
-    r'(<a\b(?=[^>]*\bhreflang="(?P<lang>zh|en)")[^>]*\bhref=")[^"]*(")',
+    r'(?P<prefix><a\b(?=[^>]*\bhreflang="(?P<lang>zh|en)")[^>]*\bhref=")[^"]*(?P<suffix>")',
     re.IGNORECASE,
 )
 
@@ -18,10 +18,10 @@ def on_post_page(output, page, config):
 
     def repl(match):
         lang = match.group("lang").lower()
-        href = en_url if lang == "en" and support_en else cn_url
         if lang == "en" and not support_en:
             return match.group(0)
-        return f"{match.group(1)}{href}{match.group(3)}"
+        href = en_url if lang == "en" else cn_url
+        return f"{match.group('prefix')}{href}{match.group('suffix')}"
 
     try:
         return _HREFLANG_HREF.sub(repl, output)

--- a/main.py
+++ b/main.py
@@ -1,15 +1,15 @@
+"""Flatten problem READMEs and generate MkDocs nav grouped by number range."""
+
 import os
 from collections import defaultdict
+from typing import Dict, List, NamedTuple, Tuple
 
 
-def get_paths(dirs: str, m: int):
-    paths = []
-    for root, _, files in os.walk(dirs):
-        for file in files:
-            file_name = os.path.join(root, file)
-            if file.endswith(".md") and len(file_name.split(os.sep)) == m:
-                paths.append(file_name)
-    return paths
+class NavItem(NamedTuple):
+    sort_key: Tuple[int, ...]
+    num: str
+    name: str
+    dest: str
 
 
 dirs_mapping = {
@@ -21,103 +21,209 @@ dirs_mapping = {
     "lcs": ("lcs", 3),
 }
 
-navdata_cn = defaultdict(list)
-navdata_en = defaultdict(list)
 
-for dir, (target_dir, m) in dirs_mapping.items():
-    for p in sorted(get_paths(dir, m)):
-        with open(p, "r", encoding="utf-8") as f:
-            content = f.read()
-            title = content[content.find("[") + 1 : content.find("]")]
-            dot = title.find(".") if dir != "lcci" else title.rfind(".")
-            num = (
-                title[:dot]
-                .replace("面试题", "")
-                .replace("剑指 Offer II", "")
-                .replace("LCP", "")
-                .replace("LCS", "")
-                .strip(" ")
-                .lstrip("0")
-            )
-            name = (
-                title[dot + 1 :]
-                .replace("面试题", "")
-                .replace("剑指 Offer II", "")
-                .replace("LCP", "")
-                .replace("LCS", "")
-                .strip(" ")
-                .lstrip("0")
-            )
-            if num.endswith("- III"):
-                num = num[:-5] + ".3"
-            elif num.endswith("- II"):
-                num = num[:-4] + ".2"
-            elif num.endswith("- I"):
-                num = num[:-3] + ".1"
-            num = ".".join([x.strip(" ").lstrip("0") for x in num.split(".")])
-            is_en = "README_EN" in p
-            if is_en:
-                navdata_en[dir].append(f"    - {num}. {name}: {target_dir}/{num}.md")
-            else:
-                navdata_cn[dir].append(f"    - {num}. {name}: {target_dir}/{num}.md")
-            docs_dir = ("docs-en" if is_en else "docs") + os.sep + target_dir
-            if not os.path.exists(docs_dir):
-                os.makedirs(docs_dir)
-            new_path = os.path.join(docs_dir, f"{num}.md")
-            with open(new_path, "w", encoding="utf-8") as f:
+def get_paths(dirs: str, m: int) -> List[str]:
+    paths = []
+    for root, _, files in os.walk(dirs):
+        for file in files:
+            file_name = os.path.join(root, file)
+            if file.endswith(".md") and len(file_name.split(os.sep)) == m:
+                paths.append(file_name)
+    return paths
+
+
+def parse_sort_key(num: str) -> Tuple[int, ...]:
+    parts = []
+    for part in num.split("."):
+        try:
+            parts.append(int(part))
+        except ValueError:
+            parts.append(0)
+    return tuple(parts) if parts else (0,)
+
+
+def parse_heading(content: str, dir_name: str) -> Tuple[str, str]:
+    title = content[content.find("[") + 1 : content.find("]")]
+    dot = title.find(".") if dir_name != "lcci" else title.rfind(".")
+    num = (
+        title[:dot]
+        .replace("面试题", "")
+        .replace("剑指 Offer II", "")
+        .replace("LCP", "")
+        .replace("LCS", "")
+        .strip(" ")
+        .lstrip("0")
+    )
+    name = (
+        title[dot + 1 :]
+        .replace("面试题", "")
+        .replace("剑指 Offer II", "")
+        .replace("LCP", "")
+        .replace("LCS", "")
+        .strip(" ")
+        .lstrip("0")
+    )
+    if num.endswith("- III"):
+        num = num[:-5] + ".3"
+    elif num.endswith("- II"):
+        num = num[:-4] + ".2"
+    elif num.endswith("- I"):
+        num = num[:-3] + ".1"
+    num = ".".join([x.strip(" ").lstrip("0") for x in num.split(".")])
+    return num, name
+
+
+def range_start(num: str) -> int:
+    return parse_sort_key(num)[0] // 100 * 100
+
+
+def range_label(start: int) -> str:
+    return f"{start:04d}–{start + 99:04d}"
+
+
+def range_slug(start: int) -> str:
+    return f"{start:04d}-{start + 99:04d}"
+
+
+def write_range_indexes(
+    items: List[NavItem], docs_root: str, target_dir: str, lang: str
+) -> None:
+    buckets: Dict[int, List[NavItem]] = defaultdict(list)
+    for item in items:
+        buckets[range_start(item.num)].append(item)
+
+    out_dir = os.path.join(docs_root, target_dir)
+    os.makedirs(out_dir, exist_ok=True)
+    heading = "本段题目" if lang == "zh" else "Problems in this range"
+
+    for start, group in buckets.items():
+        group.sort(key=lambda x: x.sort_key)
+        label = range_label(start)
+        lines = [
+            "---",
+            "hide:",
+            "  - toc",
+            "  - feedback",
+            "---",
+            "",
+            f"# {label}",
+            "",
+            f"{heading}：{len(group)}",
+            "",
+        ]
+        for item in group:
+            lines.append(f"- [{item.num}. {item.name}]({item.num}.md)")
+        lines.append("")
+        path = os.path.join(out_dir, f"{range_slug(start)}.md")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+
+
+def format_flat_nav(items: List[NavItem], indent: int = 4) -> str:
+    pad = " " * indent
+    return "\n".join(f"{pad}- {item.num}. {item.name}: {item.dest}" for item in items)
+
+
+def format_ranged_nav(items: List[NavItem], index_label: str, indent: int = 4) -> str:
+    buckets: Dict[int, List[NavItem]] = defaultdict(list)
+    for item in items:
+        buckets[range_start(item.num)].append(item)
+
+    lines = []
+    pad = " " * indent
+    child = " " * (indent + 2)
+    for start in sorted(buckets):
+        group = sorted(buckets[start], key=lambda x: x.sort_key)
+        dest_dir = group[0].dest.rsplit("/", 1)[0]
+        lines.append(f"{pad}- {range_label(start)}:")
+        lines.append(f"{child}- {index_label}: {dest_dir}/{range_slug(start)}.md")
+        for item in group:
+            lines.append(f"{child}- {item.num}. {item.name}: {item.dest}")
+    return "\n".join(lines)
+
+
+def collect_items() -> Tuple[Dict[str, List[NavItem]], Dict[str, List[NavItem]]]:
+    nav_cn: Dict[str, List[NavItem]] = defaultdict(list)
+    nav_en: Dict[str, List[NavItem]] = defaultdict(list)
+
+    for dir_name, (target_dir, depth) in dirs_mapping.items():
+        if not os.path.isdir(dir_name):
+            continue
+        for path in sorted(get_paths(dir_name, depth)):
+            with open(path, "r", encoding="utf-8") as f:
+                content = f.read()
+            num, name = parse_heading(content, dir_name)
+            dest = f"{target_dir}/{num}.md"
+            item = NavItem(parse_sort_key(num), num, name, dest)
+            is_en = "README_EN" in path
+            (nav_en if is_en else nav_cn)[dir_name].append(item)
+            docs_dir = os.path.join("docs-en" if is_en else "docs", target_dir)
+            os.makedirs(docs_dir, exist_ok=True)
+            with open(os.path.join(docs_dir, f"{num}.md"), "w", encoding="utf-8") as f:
                 f.write(content)
 
-    navdata_en[dir].sort(key=lambda x: int(x.split(".")[0].split(" ")[-1]))
-    navdata_cn[dir].sort(key=lambda x: int(x.split(".")[0].split(" ")[-1]))
+        nav_cn[dir_name].sort(key=lambda x: x.sort_key)
+        nav_en[dir_name].sort(key=lambda x: x.sort_key)
+
+    return nav_cn, nav_en
 
 
-lc, lcci = "\n".join(navdata_cn["solution"]), "\n".join(navdata_cn["lcci"])
-lcof, lcof2 = "\n".join(navdata_cn["lcof"]), "\n".join(navdata_cn["lcof2"])
+def replace_nav(config: str, nav: str) -> str:
+    if "nav:" in config:
+        config = config[: config.find("nav:")]
+    return config + nav
 
-nav_sections = f"""
 
+def main() -> None:
+    nav_cn, nav_en = collect_items()
+
+    write_range_indexes(nav_cn["solution"], "docs", "lc", "zh")
+    write_range_indexes(nav_en["solution"], "docs-en", "lc", "en")
+
+    lc = format_ranged_nav(nav_cn["solution"], "目录")
+    lcci = format_flat_nav(nav_cn["lcci"])
+    lcof = format_flat_nav(nav_cn["lcof"])
+    lcof2 = format_flat_nav(nav_cn["lcof2"])
+
+    nav_sections = f"""
 nav:
   - 首页: index.md
-  - LeetCode 全解:\n{lc}
-  - 剑指 Offer:\n{lcof}
-  - 剑指 Offer（专项突破）:\n{lcof2}
-  - 程序员面试金典:\n{lcci}
+  - LeetCode 全解:
+{lc}
+  - 剑指 Offer:
+{lcof}
+  - 剑指 Offer（专项突破）:
+{lcof2}
+  - 程序员面试金典:
+{lcci}
   - 专项训练: tags.md
   - 竞赛专区: contest.md
-
 """
 
-lc, lcci = "\n".join(navdata_en["solution"]), "\n".join(navdata_en["lcci"])
+    lc_en = format_ranged_nav(nav_en["solution"], "Index")
+    lcci_en = format_flat_nav(nav_en["lcci"])
 
-en_nav_sections = f"""
-
+    en_nav_sections = f"""
 nav:
   - Home: index.md
-  - LeetCode:\n{lc}
-  - Cracking the Coding Interview:\n{lcci}
+  - LeetCode:
+{lc_en}
+  - Cracking the Coding Interview:
+{lcci_en}
   - Focused Training: tags.md
   - Contest: contest.md
-
 """
 
-# load mkdocs config
-with open("mkdocs.yml", "r", encoding="utf-8") as f:
-    config = f.read()
-with open("mkdocs-en.yml", "r", encoding="utf-8") as f:
-    en_config = f.read()
+    with open("mkdocs.yml", "r", encoding="utf-8") as f:
+        config = f.read()
+    with open("mkdocs-en.yml", "r", encoding="utf-8") as f:
+        en_config = f.read()
 
-# delete old nav config
-if "nav:" in config:
-    config = config[: config.find("nav:")]
-if "nav:" in en_config:
-    en_config = en_config[: en_config.find("nav:")]
+    with open("mkdocs.yml", "w", encoding="utf-8") as f:
+        f.write(replace_nav(config, nav_sections))
+    with open("mkdocs-en.yml", "w", encoding="utf-8") as f:
+        f.write(replace_nav(en_config, en_nav_sections))
 
-# add new nav config
-config += nav_sections
-en_config += en_nav_sections
 
-# write new config
-with open("mkdocs.yml", "w", encoding="utf-8") as f:
-    f.write(config)
-with open("mkdocs-en.yml", "w", encoding="utf-8") as f:
-    f.write(en_config)
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -95,6 +95,7 @@ def write_range_indexes(
     out_dir = os.path.join(docs_root, target_dir)
     os.makedirs(out_dir, exist_ok=True)
     heading = "本段题目" if lang == "zh" else "Problems in this range"
+    colon = "：" if lang == "zh" else ": "
 
     for start, group in buckets.items():
         group.sort(key=lambda x: x.sort_key)
@@ -108,7 +109,7 @@ def write_range_indexes(
             "",
             f"# {label}",
             "",
-            f"{heading}：{len(group)}",
+            f"{heading}{colon}{len(group)}",
             "",
         ]
         for item in group:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,8 @@ theme:
     # - navigation.instant.prefetch
     # - navigation.instant.progress
     - navigation.prune
-    - navigation.sections
+    # sections would mark each 100-problem range as is_section and skip prune
+    # - navigation.sections
     - navigation.tabs
     # - navigation.tabs.sticky
     - navigation.top

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ theme:
     # - navigation.instant
     # - navigation.instant.prefetch
     # - navigation.instant.progress
-    # - navigation.prune
+    - navigation.prune
     - navigation.sections
     - navigation.tabs
     # - navigation.tabs.sticky


### PR DESCRIPTION
## Summary
- Group the LeetCode sidebar into 100-problem ranges (`0000–0099`, …) and generate a directory page per range.
- Enable Material `navigation.prune` so each HTML page only embeds the current range (keeps minify).
- Replace per-page BeautifulSoup language switching with a regex rewrite; drop the committer cache dump.

## Test plan
- [ ] Merge to `docs`, then run **workflow_dispatch** on `deploy` (or merge the companion deploy.yml PR)
- [ ] Confirm a problem page sidebar shows ~100 items plus collapsed range titles
- [ ] Click a range title → range directory; search and `/lc/3876/` still work
- [ ] Compare `Documentation built in … seconds` and `github-pages` artifact size to the previous ~80 min / ~829 MB
