### PR TITLE
ci: skip prettier on PRs that do not target main

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -15,7 +15,7 @@ jobs:
     # Only run for PRs from the SAME repository.
     # Fork PRs are skipped entirely to prevent RCE via pnpm install.
     # ---------------------------------------------------------
-    if: ${{ github.event.pull_request.head.repo.fork == false }}
+    if: ${{ github.event.pull_request.head.repo.fork == false && github.event.pull_request.base.ref == 'main' }}
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Skip the prettier `pull_request_target` job when the PR base is not `main`.
- Docs-based PRs (orphan branch, no `package.json`) were failing with `No pnpm version is specified`.

## Test plan
- [ ] After merge, re-run format on #5393 — should skip, not fail
- [ ] A PR targeting `main` still runs prettier
