### PR TITLE
fix: keep language switcher on the current problem page

### DIFF
--- a/hooks/stay_on_page.py
+++ b/hooks/stay_on_page.py
@@ -1,16 +1,32 @@
 import re
 
+# Minify may strip quotes: <a href=/en/ hreflang=en>
 _HREFLANG_HREF = re.compile(
-    r'(?P<prefix><a\b(?=[^>]*\bhreflang="(?P<lang>zh|en)")[^>]*\bhref=")[^"]*(?P<suffix>")',
-    re.IGNORECASE,
+    r"""
+    (?P<prefix>
+        <a\b
+        (?=[^>]*\bhreflang=(?P<lq>["']?)(?P<lang>zh|en)(?P=lq)(?=[\s>]))
+        [^>]*\bhref=(?P<hq>["']?)
+    )
+    [^"'\s>]*
+    (?P<suffix>(?P=hq))
+    """,
+    re.IGNORECASE | re.VERBOSE,
 )
+
+
+def _page_rel(page) -> str:
+    url = (getattr(page, "url", None) or "").strip().lstrip("/")
+    if url in ("", "./", "index.html", "index.htm"):
+        return ""
+    return url
 
 
 def on_post_page(output, page, config):
     if not output:
         return output
 
-    rel = (page.url or "").lstrip("/")
+    rel = _page_rel(page)
     cn_url = f"/{rel}" if rel else "/"
     en_url = f"/en/{rel}" if rel else "/en/"
     prefix = rel.split("/", 1)[0] if rel else ""


### PR DESCRIPTION
## Summary

- Language switcher on live pages still points to `/` and `/en/` because `minify_html` strips attribute quotes (`hreflang=en`, `href=/en/`).
- `stay_on_page` only matched quoted `hreflang="en"` / `href="..."`, so it never rewrote the current problem URL after #5393.
- Accept quoted and unquoted attributes so `/lc/1/` stays on `/en/lc/1/` (and the reverse).

## Test plan

- [x] Unit-tested quoted, minified, single-quoted, and live-site snippets
- [ ] After merge/deploy, open https://leetcode.doocs.org/lc/1/ and switch to English — should land on `/en/lc/1/`
- [ ] From `/en/lc/1/`, switch back to 中文 — should land on `/lc/1/`
- [ ] 剑指 Offer pages should still send English to `/en/` (no English counterparts)
