### PR TITLE
ci: lint only changed files and fix formatter docs

### DIFF
--- a/.github/workflows/black-lint.yml
+++ b/.github/workflows/black-lint.yml
@@ -28,7 +28,14 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install black
-        run: python -m pip install "$(grep '^black==' requirements.txt)"
+        run: |
+          set -euo pipefail
+          pin="$(grep '^black==' requirements.txt || true)"
+          if [ -z "$pin" ]; then
+            echo "requirements.txt must contain a black== version pin."
+            exit 1
+          fi
+          python -m pip install "$pin"
       - name: Check black
         run: |
           set -euo pipefail

--- a/.github/workflows/black-lint.yml
+++ b/.github/workflows/black-lint.yml
@@ -4,41 +4,46 @@ on:
   push:
     branches: [main]
     paths:
-      - solution/**
-      - lcs/**
-      - lcp/**
-      - lcof2/**
-      - lcof/**
-      - lcci/**
-      - basic/**
+      - '**/*.py'
       - requirements.txt
       - .github/workflows/black-lint.yml
   pull_request:
     paths:
-      - solution/**
-      - lcs/**
-      - lcp/**
-      - lcof2/**
-      - lcof/**
-      - lcci/**
-      - basic/**
+      - '**/*.py'
       - requirements.txt
       - .github/workflows/black-lint.yml
 
 concurrency:
-  group: ${{github.workflow}} - ${{github.ref}}
+  group: ${{ github.workflow }} - ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install black
-        run: python -m pip install -r requirements.txt
+        run: python -m pip install "$(grep '^black==' requirements.txt)"
       - name: Check black
-        run: python -m black -S --check .
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            mapfile -t files < <(git diff --name-only --diff-filter=ACMR "${{ github.event.pull_request.base.sha }}" -- '*.py' || true)
+          else
+            before="${{ github.event.before }}"
+            if [ -z "$before" ] || [[ "$before" =~ ^0+$ ]]; then
+              echo "No previous commit; skip black."
+              exit 0
+            fi
+            mapfile -t files < <(git diff --name-only --diff-filter=ACMR "$before" "${{ github.sha }}" -- '*.py' || true)
+          fi
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No Python files changed."
+            exit 0
+          fi
+          python -m black -S --check "${files[@]}"

--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -4,37 +4,47 @@ on:
   push:
     branches: [main]
     paths:
-      - solution/**
-      - lcs/**
-      - lcp/**
-      - lcof2/**
-      - lcof/**
-      - lcci/**
-      - basic/**
+      - '**/*.c'
+      - '**/*.cpp'
+      - '**/*.java'
+      - .clang-format
       - .github/workflows/clang-format-lint.yml
   pull_request:
     paths:
-      - solution/**
-      - lcs/**
-      - lcp/**
-      - lcof2/**
-      - lcof/**
-      - lcci/**
-      - basic/**
+      - '**/*.c'
+      - '**/*.cpp'
+      - '**/*.java'
+      - .clang-format
       - .github/workflows/clang-format-lint.yml
 
 concurrency:
-  group: ${{github.workflow}} - ${{github.ref}}
+  group: ${{ github.workflow }} - ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v7
-      - uses: DoozyX/clang-format-lint-action@v0.20
         with:
-          source: '.'
-          extensions: 'c,cpp,java'
-          clangFormatVersion: 16
+          fetch-depth: 0
+      - name: Install clang-format
+        run: python3 -m pip install clang-format==16.0.6
+      - name: Check clang-format
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            mapfile -t files < <(git diff --name-only --diff-filter=ACMR "${{ github.event.pull_request.base.sha }}" -- '*.c' '*.cpp' '*.java' || true)
+          else
+            before="${{ github.event.before }}"
+            if [ -z "$before" ] || [[ "$before" =~ ^0+$ ]]; then
+              echo "No previous commit; skip clang-format."
+              exit 0
+            fi
+            mapfile -t files < <(git diff --name-only --diff-filter=ACMR "$before" "${{ github.sha }}" -- '*.c' '*.cpp' '*.java' || true)
+          fi
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No C/C++/Java files changed."
+            exit 0
+          fi
+          clang-format --dry-run --Werror --style=file "${files[@]}"

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -28,10 +28,11 @@ jobs:
                 
                 我们项目中各种编程语言代码（包括文档）所采用的格式化工具不同，提交 pr 之前必须确保代码、文档正确格式化。
 
-                -   .{md,js,ts,php,sql,rs} 采用 prettier
+                -   .{md,js,ts,php,sql} 采用 prettier
                 -   .{c,cpp,java} 采用 clang-format
                 -   .{py} 采用 black
                 -   .{go} 采用 gofmt
+                -   .{rs} 采用 rustfmt
                 -   其它待完善
 
                 ### 2. Git 提交信息
@@ -55,10 +56,11 @@ jobs:
 
                 We use different formatting tools for various programming languages (including documentation) in our project. You must ensure that the code and documentation are correctly formatted before submitting a pr.
                 
-                -   .{md,js,ts,php,sql,rs} use prettier
+                -   .{md,js,ts,php,sql} use prettier
                 -   .{c,cpp,java} use clang-format
                 -   .{py} use black
                 -   .{go} use gofmt
+                -   .{rs} use rustfmt
                 -   Others to be improved
 
                 ### 2. Git Commit Message

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -1,0 +1,43 @@
+name: prettier-check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.js'
+      - '**/*.ts'
+      - '**/*.php'
+      - '**/*.sql'
+      - '**/*.md'
+      - .prettierignore
+      - package.json
+      - pnpm-lock.yaml
+      - .github/workflows/prettier-check.yml
+
+concurrency:
+  group: ${{ github.workflow }} - ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Check prettier
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "${{ github.event.pull_request.base.sha }}" -- '*.js' '*.ts' '*.php' '*.sql' '*.md' || true)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No Prettier files changed."
+            exit 0
+          fi
+          git config --global core.quotepath off
+          pnpm exec prettier --check "${files[@]}"

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: 22
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Check prettier
         run: |
           set -euo pipefail

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,11 +68,11 @@ pnpm run setup:python     # Optional: black and the problem-sync spider
 
 GitHub Actions automatically run:
 
-- **clang-format** lint on C/C++/Java files
-- **Black** lint on Python files
-- **gofmt** lint on Go files
-- **rustfmt** lint on Rust files
-- **Prettier** on JS/TS/PHP/SQL/Markdown files
+- **clang-format** lint on changed C/C++/Java files
+- **Black** lint on changed Python files
+- **gofmt** lint on changed Go files
+- **rustfmt** lint on changed Rust files
+- **Prettier** on JS/TS/PHP/SQL/Markdown files (auto-format same-repo PRs; `--check` on all PRs)
 - **Deploy** workflow for the documentation site
 
 ## Solution Patterns


### PR DESCRIPTION
## Summary

- clang-format and black now lint only changed files, matching gofmt/rustfmt.
- Add `prettier-check` on `pull_request` so fork PRs get a format gate without `pull_request_target` installs.
- pr-checker (and AGENTS.md) list rustfmt for `.rs` instead of prettier.

## Test plan

- [ ] Open a PR that touches one `.py` / `.cpp` file and confirm black / clang-format only mention those paths
- [ ] Confirm a markdown-only PR still runs prettier-check and skips clang/black
- [ ] Confirm pr-checker comment on a new external PR lists rustfmt
