### PR TITLE
chore: remove deprecated main.py site-builder alias

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,0 @@
-"""Deprecated alias for old deploy.yml. Prefer: python3 build_site.py"""
-
-from build_site import main
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Summary

- Delete the deprecated `main.py` alias. Site builds use `build_site.py` only.

## Test plan

- [ ] Merge with or after the parallel deploy PR
- [ ] Deploy finds `build_site.py` and does not look for `main.py`
