### PR TITLE
ci: coalesce deploy requests and never cancel a started build

### DIFF
--- a/.github/workflows/deploy-request.yml
+++ b/.github/workflows/deploy-request.yml
@@ -1,0 +1,31 @@
+name: deploy-request
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - solution/**
+      - lcs/**
+      - lcp/**
+      - lcof2/**
+      - lcof/**
+      - lcci/**
+      - basic/**
+
+concurrency:
+  group: deploy-request
+  cancel-in-progress: true
+
+jobs:
+  request:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Wait for a quiet period
+        run: sleep 90
+      - name: Dispatch deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run deploy.yml --ref main --repo "${{ github.repository }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,18 +6,11 @@ on:
     branches:
       - main
     paths:
-      - solution/**
-      - lcs/**
-      - lcp/**
-      - lcof2/**
-      - lcof/**
-      - lcci/**
-      - basic/**
       - .github/workflows/deploy.yml
 
 concurrency:
   group: deploy-site
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ GitHub Actions automatically run:
 - **gofmt** lint on changed Go files
 - **rustfmt** lint on changed Rust files
 - **Prettier** on JS/TS/PHP/SQL/Markdown files (auto-format same-repo PRs; `--check` on all PRs)
-- **Deploy** overlays the `docs` branch site engine onto `main` content (whitelist only) and builds GitHub Pages
+- **Deploy** overlays the `docs` branch site engine onto `main` content (whitelist only) and builds GitHub Pages. Content pushes wait ~90s and coalesce; a started site build is not cancelled.
 
 ## Solution Patterns
 


### PR DESCRIPTION
## Summary

- Do not cancel a site build that has already started (`cancel-in-progress: false` on `deploy.yml`).
- Content pushes no longer start `deploy.yml` directly. `deploy-request.yml` waits 90s with cancel-in-progress, then dispatches one deploy. Rapid merges only cancel the cheap wait job.
- Changing `deploy.yml` still deploys immediately. Manual `workflow_dispatch` is unchanged.

## Test plan

- [ ] Merge several solution PRs within a minute: only one `deploy` should start after ~90s
- [ ] While a deploy is running, merge another solution PR: the next deploy should queue, not cancel the running one
- [ ] `workflow_dispatch` on `deploy.yml` still starts immediately
