### PR TITLE
ci: skip stale main deploy dispatch after the quiet period

### DIFF
--- a/.github/workflows/deploy-request.yml
+++ b/.github/workflows/deploy-request.yml
@@ -22,10 +22,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      contents: read
     steps:
       - name: Wait for a quiet period
         run: sleep 90
-      - name: Dispatch deploy
+      - name: Dispatch deploy if this commit is still main HEAD
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run deploy.yml --ref main --repo "${{ github.repository }}"
+          REPO: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          tip="$(gh api "repos/${REPO}/commits/${REF_NAME}" --jq .sha)"
+          if [ "$tip" != "$SHA" ]; then
+            echo "main HEAD is ${tip}; this run is ${SHA}. Skip stale dispatch."
+            exit 0
+          fi
+          gh workflow run deploy.yml --ref main --repo "${REPO}"


### PR DESCRIPTION
## Summary

- After the 90s quiet period, dispatch `deploy.yml` only if this run's commit is still `main` HEAD.
- Same race fix as the docs `trigger-deploy` workflow.

## Test plan

- [ ] Two solution pushes within 90s: at most one deploy after the later wait
- [ ] A push that is no longer HEAD after sleep logs skip and does not dispatch
