### PR TITLE
ci: fail spider formatters and skip deleted prettier files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,10 +110,9 @@ jobs:
             printf '%s\n' '---' 'comments: true' '---' '' '# LeetCode Contest' '' 'The contest list is not included in this build.' > docs-en/contest.md
           fi
 
-      - name: Set MKDOCS_API_KEYS
-        run: echo "MKDOCS_API_KEYS=${{ secrets.MKDOCS_API_KEYS }}" >> $GITHUB_ENV
-
       - name: Build ${{ matrix.lang }} site
+        env:
+          MKDOCS_API_KEYS: ${{ secrets.MKDOCS_API_KEYS }}
         run: |
           python3 build_site.py
           mkdocs build -f ${{ matrix.config }}

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
-concurrency: 
+concurrency:
   group: ${{github.workflow}} - ${{github.ref}}
   cancel-in-progress: true
 
@@ -33,17 +33,19 @@ jobs:
         with:
           node-version: 22
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Run prettier
         run: |
+          set -euo pipefail
           git config --global core.quotepath off
-          changed_files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" | grep -E '\.js$|\.ts$|\.php$|\.sql$|\.md$' || true)
-          if [ -n "$changed_files" ]; then
-            echo "Running prettier on the changed files"
-            echo "$changed_files" | xargs -d '\n' pnpm exec prettier --write
-          else
+          git fetch --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "${{ github.event.pull_request.base.sha }}" -- '*.js' '*.ts' '*.php' '*.sql' '*.md' || true)
+          if [ ${#files[@]} -eq 0 ]; then
             echo "No matching files to run prettier on."
+            exit 0
           fi
+          echo "Running prettier on the changed files"
+          pnpm exec prettier --write "${files[@]}"
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v7
         with:

--- a/solution/main.py
+++ b/solution/main.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import time
 from datetime import timezone, timedelta, datetime
@@ -419,11 +420,12 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def format_rust_files() -> None:
     skip = {"node_modules", "__pycache__", ".git"}
-    rs_files = [
-        str(path)
-        for path in ROOT.rglob("*.rs")
-        if path.is_file() and skip.isdisjoint(path.parts)
-    ]
+    rs_files = []
+    for dirpath, dirnames, filenames in os.walk(ROOT):
+        dirnames[:] = [name for name in dirnames if name not in skip]
+        for name in filenames:
+            if name.endswith(".rs"):
+                rs_files.append(os.path.join(dirpath, name))
     for i in range(0, len(rs_files), 64):
         subprocess.check_call(["rustfmt", *rs_files[i : i + 64]])
 

--- a/solution/main.py
+++ b/solution/main.py
@@ -1,7 +1,7 @@
-import platform
 import subprocess
 import time
 from datetime import timezone, timedelta, datetime
+from pathlib import Path
 
 import requests
 import urllib3
@@ -414,54 +414,18 @@ def get_contests(fetch_new=True) -> List:
 
 ########################################################################################
 
-
-def format_rust_files_linux():
-    # The find command to locate and format all .rs files in Linux
-    find_command = 'find . -name "*.rs" -exec rustfmt {} \\;'
-
-    # Execute the command
-    process = subprocess.Popen(
-        find_command,
-        shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-
-    # Get the output and errors
-    stdout, stderr = process.communicate()
-
-    if process.returncode == 0:
-        print("Rust files formatted successfully on Linux!")
-        print(stdout)
-    else:
-        print("Error formatting Rust files on Linux:")
-        print(stderr)
+ROOT = Path(__file__).resolve().parents[1]
 
 
-def format_rust_files_windows():
-    # PowerShell command to format all .rs files recursively in Windows
-    ps_command = (
-        "Get-ChildItem -Recurse -Filter *.rs | ForEach-Object { rustfmt $_.FullName }"
-    )
-
-    # Execute the PowerShell command
-    process = subprocess.Popen(
-        ["powershell", "-Command", ps_command],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-
-    # Get the output and errors
-    stdout, stderr = process.communicate()
-
-    if process.returncode == 0:
-        print("Rust files formatted successfully on Windows!")
-        print(stdout)
-    else:
-        print("Error formatting Rust files on Windows:")
-        print(stderr)
+def format_rust_files() -> None:
+    skip = {"node_modules", "__pycache__", ".git"}
+    rs_files = [
+        str(path)
+        for path in ROOT.rglob("*.rs")
+        if path.is_file() and skip.isdisjoint(path.parts)
+    ]
+    for i in range(0, len(rs_files), 64):
+        subprocess.check_call(["rustfmt", *rs_files[i : i + 64]])
 
 
 def run():
@@ -540,15 +504,11 @@ def run():
     generate_category_readme(ls, "JavaScript")
 
     refresh(ls)
-    # 格式化
-    os.system('cd .. && npx prettier --write "**/*.{md,js,ts,php,sql}"')
-
-    # 格式化 rust 代码
-    # 判断当前是 windows 还是 linux
-    if platform.system() == "Linux":
-        format_rust_files_linux()
-    elif platform.system() == "Windows":
-        format_rust_files_windows()
+    subprocess.check_call(
+        ["npx", "prettier", "--write", "**/*.{md,js,ts,php,sql}"],
+        cwd=ROOT,
+    )
+    format_rust_files()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Problem-sync spider no longer swallows prettier/rustfmt failures (`os.system` / `find` / PowerShell). rustfmt also runs on macOS now.
- Same-repo prettier auto-format matches prettier-check: only added/copied/modified/renamed files, `--ignore-scripts`, and an explicit fetch of the PR base SHA.
- Pass `MKDOCS_API_KEYS` as a build-step env instead of echoing the secret into `GITHUB_ENV`.

## Test plan

- [ ] Open a same-repo PR that deletes a markdown file: prettier workflow should not try to format the deleted path
- [ ] Open a same-repo PR that edits a markdown file: prettier still reformats and commits if needed
- [ ] After merge, a `deploy.yml` run still sees `MKDOCS_API_KEYS` during `mkdocs build`

Made with [Cursor](https://cursor.com)