### PR TITLE
ci: bump remaining GitHub Actions majors and drop issues-helper

### DIFF
--- a/.github/workflows/black-lint.yml
+++ b/.github/workflows/black-lint.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.x'
       - name: Install black

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,12 +43,12 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: 3.x
 
       - name: Restore pip cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-docs-${{ matrix.lang }}-${{ hashFiles('mkdocs/requirements.txt') }}

--- a/.github/workflows/gofmt-lint.yml
+++ b/.github/workflows/gofmt-lint.yml
@@ -24,10 +24,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: stable
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.x'
       - name: Check gofmt

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   issue-labeled:
     permissions:
-      pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: supplement

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -10,29 +10,37 @@ permissions:
 jobs:
   issue-labeled:
     permissions:
-      pull-requests: write # for actions-cool/issues-helper to update PRs
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: supplement
         if: github.event.label.name == 'supplement'
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@v9
         with:
-          actions: "create-comment"
-          token: ${{ secrets.DOOCS_BOT_ACTION_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            @${{ github.event.pull_request.user.login }}, Please add the missing README_EN.md / README.md, please refer to the details for https://github.com/doocs/leetcode/pull/2590/files
+          github-token: ${{ secrets.DOOCS_BOT_ACTION_TOKEN }}
+          script: |
+            const login = context.payload.pull_request.user.login;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body:
+                `@${login}, Please add the missing README_EN.md / README.md, please refer to the details for https://github.com/doocs/leetcode/pull/2590/files\n\n` +
+                `@${login}, 请补充缺少的 README_EN.md / README.md, 详情参考 https://github.com/doocs/leetcode/pull/2590/files`,
+            });
 
-            @${{ github.event.pull_request.user.login }}, 请补充缺少的 README_EN.md / README.md, 详情参考 https://github.com/doocs/leetcode/pull/2590/files
-      
       - name: invalid
         if: github.event.label.name == 'invalid'
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@v9
         with:
-          actions: "create-comment"
-          token: ${{ secrets.DOOCS_BOT_ACTION_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            @${{ github.event.pull_request.user.login }}, Please refer to the project specifications provided by bot to check your PR. For PRs that have not been modified for a long time, we will close them and you are welcome to resubmit or correct them.
-
-            @${{ github.event.pull_request.user.login }}, 请参考 bot 提供的项目规范检查你的 PR，我们会关闭长时间未修改的 PR，欢迎你重新提交或更正。
+          github-token: ${{ secrets.DOOCS_BOT_ACTION_TOKEN }}
+          script: |
+            const login = context.payload.pull_request.user.login;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body:
+                `@${login}, Please refer to the project specifications provided by bot to check your PR. For PRs that have not been modified for a long time, we will close them and you are welcome to resubmit or correct them.\n\n` +
+                `@${login}, 请参考 bot 提供的项目规范检查你的 PR，我们会关闭长时间未修改的 PR，欢迎你重新提交或更正。`,
+            });


### PR DESCRIPTION
## Summary

- Bump `actions/setup-python` v6 → v7, `actions/setup-go` v6 → v7, and `actions/cache` v5 → v6 (ESM / current majors; no input changes we rely on).
- Replace `actions-cool/issues-helper@v3` in `pr-labeled.yml`. That repository is TOS-blocked on GitHub, so label comments now use `actions/github-script@v9` like `pr-checker.yml`.

Left unchanged because they are already on the current major or the pinned SHA is HEAD:

- `checkout@v7`, `setup-node@v7`, `github-script@v9`, `upload-artifact@v7`, `download-artifact@v8`, `upload-pages-artifact@v5`, `deploy-pages@v5`, `pnpm/action-setup@v6`, `git-auto-commit-action@v7`, `create-pull-request@v8`
- SHA pins: `calibreapp/image-actions` v1.5.0, `dtolnay/rust-toolchain` stable, `MaoLongLong/actions-starcharts` main, `actionv/pr-label-action` master

## Test plan

- [ ] `black-lint` / `gofmt-lint` still run on a Python or Go change
- [ ] Next site deploy still restores the pip cache
- [ ] Label a PR `supplement` and `invalid`: bot comments still post

Made with [Cursor](https://cursor.com)