### PR TITLE
ci: add dependabot, pin runtimes, and share site prepare

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/scripts/fetch-diff-base.sh
+++ b/.github/scripts/fetch-diff-base.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+  git fetch --no-tags --depth=1 origin "${PR_BASE_SHA}"
+  exit 0
+fi
+before="${GIT_BEFORE:-}"
+if [ -z "$before" ] || [[ "$before" =~ ^0+$ ]]; then
+  exit 0
+fi
+git fetch --no-tags --depth=1 origin "$before"

--- a/.github/workflows/black-lint.yml
+++ b/.github/workflows/black-lint.yml
@@ -7,11 +7,13 @@ on:
       - '**/*.py'
       - requirements.txt
       - .github/workflows/black-lint.yml
+      - .github/scripts/fetch-diff-base.sh
   pull_request:
     paths:
       - '**/*.py'
       - requirements.txt
       - .github/workflows/black-lint.yml
+      - .github/scripts/fetch-diff-base.sh
 
 concurrency:
   group: ${{ github.workflow }} - ${{ github.ref }}
@@ -23,10 +25,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+      - name: Fetch diff base
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GIT_BEFORE: ${{ github.event.before }}
+        run: bash .github/scripts/fetch-diff-base.sh
       - uses: actions/setup-python@v7
         with:
-          python-version: '3.x'
+          python-version: '3.13'
       - name: Install black
         run: |
           set -euo pipefail

--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -9,6 +9,7 @@ on:
       - '**/*.java'
       - .clang-format
       - .github/workflows/clang-format-lint.yml
+      - .github/scripts/fetch-diff-base.sh
   pull_request:
     paths:
       - '**/*.c'
@@ -16,6 +17,7 @@ on:
       - '**/*.java'
       - .clang-format
       - .github/workflows/clang-format-lint.yml
+      - .github/scripts/fetch-diff-base.sh
 
 concurrency:
   group: ${{ github.workflow }} - ${{ github.ref }}
@@ -27,7 +29,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+      - name: Fetch diff base
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GIT_BEFORE: ${{ github.event.before }}
+        run: bash .github/scripts/fetch-diff-base.sh
       - name: Install clang-format
         run: python3 -m pip install clang-format==16.0.6
       - name: Check clang-format

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,11 @@ jobs:
           path: mkdocs
           fetch-depth: 1
 
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
       - name: Overlay docs site engine
         run: |
           set -euo pipefail

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,18 +13,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  prepare:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - lang: zh
-            config: mkdocs.yml
-            site_path: site
-          - lang: en
-            config: mkdocs-en.yml
-            site_path: site/en
     permissions:
       contents: read
       actions: write
@@ -33,38 +23,23 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Checkout docs branch
         uses: actions/checkout@v7
         with:
           ref: docs
           path: mkdocs
-          fetch-depth: 0
-
-      - name: Setup Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: 3.x
-
-      - name: Restore pip cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-docs-${{ matrix.lang }}-${{ hashFiles('mkdocs/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-docs-${{ matrix.lang }}-
-            ${{ runner.os }}-pip-docs-
-
-      - name: Install site dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r mkdocs/requirements.txt
-          sudo apt-get install -y pngquant
+          fetch-depth: 1
 
       - name: Overlay docs site engine
         run: |
           set -euo pipefail
+          if [ ! -f mkdocs/requirements.txt ]; then
+            echo "docs branch is missing requirements.txt."
+            exit 1
+          fi
+          cp mkdocs/requirements.txt requirements-docs.txt
           items=(
             docs
             docs-en
@@ -97,13 +72,76 @@ jobs:
             echo "warning: solution/CONTEST_README_EN.md missing; writing a stub."
             printf '%s\n' '---' 'comments: true' '---' '' '# LeetCode Contest' '' 'The contest list is not included in this build.' > docs-en/contest.md
           fi
+          python3 build_site.py
+
+      - name: Upload prepared site sources
+        uses: actions/upload-artifact@v7
+        with:
+          name: prepared-site
+          include-hidden-files: true
+          if-no-files-found: error
+          path: |
+            docs
+            docs-en
+            hooks
+            overrides
+            mkdocs.yml
+            mkdocs-en.yml
+            build_site.py
+            requirements-docs.txt
+            .git-committers-cache.json
+
+  build:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - lang: zh
+            config: mkdocs.yml
+            site_path: site
+          - lang: en
+            config: mkdocs-en.yml
+            site_path: site/en
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Download prepared site sources
+        uses: actions/download-artifact@v8
+        with:
+          name: prepared-site
+          path: .
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Restore pip cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-docs-${{ hashFiles('requirements-docs.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-docs-
+
+      - name: Install site dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements-docs.txt
 
       - name: Build ${{ matrix.lang }} site
         env:
           MKDOCS_API_KEYS: ${{ secrets.MKDOCS_API_KEYS }}
-        run: |
-          python3 build_site.py
-          mkdocs build -f ${{ matrix.config }}
+        run: mkdocs build -f ${{ matrix.config }}
 
       - name: Upload ${{ matrix.lang }} site
         uses: actions/upload-artifact@v7

--- a/.github/workflows/gofmt-lint.yml
+++ b/.github/workflows/gofmt-lint.yml
@@ -7,11 +7,13 @@ on:
       - '**/*.go'
       - run_format.py
       - .github/workflows/gofmt-lint.yml
+      - .github/scripts/fetch-diff-base.sh
   pull_request:
     paths:
       - '**/*.go'
       - run_format.py
       - .github/workflows/gofmt-lint.yml
+      - .github/scripts/fetch-diff-base.sh
 
 concurrency:
   group: ${{ github.workflow }} - ${{ github.ref }}
@@ -23,13 +25,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+      - name: Fetch diff base
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GIT_BEFORE: ${{ github.event.before }}
+        run: bash .github/scripts/fetch-diff-base.sh
       - uses: actions/setup-go@v7
         with:
           go-version: stable
       - uses: actions/setup-python@v7
         with:
-          python-version: '3.x'
+          python-version: '3.13'
       - name: Check gofmt
         run: |
           set -euo pipefail

--- a/.github/workflows/pr-add-label.yml
+++ b/.github/workflows/pr-add-label.yml
@@ -12,14 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'doocs/leetcode'
     steps:
-      - name: Check PR number
-        id: pr_number
-        run: echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-
       - name: Run add-label Action
         uses: actionv/pr-label-action@907fc236390396b7a1198624d6b26241cfc25fa3 # master
         with:
           github_token: ${{ secrets.DOOCS_BOT_ACTION_TOKEN }}
-          pr_number: ${{ env.PR_NUMBER }}
+          pr_number: ${{ github.event.pull_request.number }}
           organize_name: "doocs"
           team_name: "leetcode-algorithm"

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     types: [opened]
 
-concurrency: 
+concurrency:
   group: ${{github.workflow}} - ${{github.ref}}
   cancel-in-progress: true
 
@@ -33,7 +33,7 @@ jobs:
                 -   .{py} 采用 black
                 -   .{go} 采用 gofmt
                 -   .{rs} 采用 rustfmt
-                -   其它待完善
+                -   .{cs} 与仓库现有 Solution.cs 风格保持一致
 
                 ### 2. Git 提交信息
 
@@ -61,7 +61,7 @@ jobs:
                 -   .{py} use black
                 -   .{go} use gofmt
                 -   .{rs} use rustfmt
-                -   Others to be improved
+                -   .{cs} match the existing Solution.cs style
 
                 ### 2. Git Commit Message
 

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -13,6 +13,7 @@ on:
       - package.json
       - pnpm-lock.yaml
       - .github/workflows/prettier-check.yml
+      - .github/scripts/fetch-diff-base.sh
 
 concurrency:
   group: ${{ github.workflow }} - ${{ github.ref }}
@@ -24,11 +25,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+      - name: Fetch diff base
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: bash .github/scripts/fetch-diff-base.sh
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Check prettier

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -25,13 +25,13 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Install pnpm
         uses: pnpm/action-setup@v6
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Run prettier

--- a/.github/workflows/rustfmt-lint.yml
+++ b/.github/workflows/rustfmt-lint.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - '**/*.rs'
       - .github/workflows/rustfmt-lint.yml
+      - .github/scripts/fetch-diff-base.sh
   pull_request:
     paths:
       - '**/*.rs'
       - .github/workflows/rustfmt-lint.yml
+      - .github/scripts/fetch-diff-base.sh
 
 concurrency:
   group: ${{ github.workflow }} - ${{ github.ref }}
@@ -21,7 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+      - name: Fetch diff base
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GIT_BEFORE: ${{ github.event.before }}
+        run: bash .github/scripts/fetch-diff-base.sh
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
         with:
           toolchain: stable


### PR DESCRIPTION
## Summary

- Add Dependabot (weekly GitHub Actions, npm, pip).
- Pin Python 3.13 and Node 24 instead of floating `3.x` / Node 22.
- Run overlay + `build_site.py` once in a `prepare` job; zh/en only `mkdocs build`. Drop unused `pngquant`.
- Lint workflows use `fetch-depth: 1` plus `.github/scripts/fetch-diff-base.sh` instead of full history.
- `pr-add-label` passes the PR number directly; `pr-checker` drops the trailing space and documents C# style instead of “others to be improved”.

Not in this PR: CSharpier, README js/ts/php/cs blocks, LCP/LCS nav, MkDocs plugin rewrite.

## Test plan

- [ ] After merge, Dependabot opens grouped Actions update PRs on schedule
- [ ] Next `deploy.yml` run: one prepare job, then parallel zh/en; site still publishes
- [ ] `committer-cache-*` artifacts still upload (hidden file)
- [ ] A Python/Go/Rust/C++ PR still runs the matching linter against the base diff

Made with [Cursor](https://cursor.com)