### PR TITLE
chore(deps): pin Python packages and bump pnpm to 11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  - package-ecosystem: pip
+    directory: /
+    target-branch: docs
+    schedule:
+      interval: weekly

--- a/package.json
+++ b/package.json
@@ -20,5 +20,5 @@
     "*.go": "node scripts/run-py.js run_format.py --gofmt",
     "*.rs": "rustfmt"
   },
-  "packageManager": "pnpm@10.34.5"
+  "packageManager": "pnpm@11.25.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 black==26.5.1
-PyYAML
-Requests
-urllib3
+PyYAML==6.0.3
+requests==2.34.2
+urllib3==2.7.0


### PR DESCRIPTION
## Summary
- Pin `requirements.txt` to current PyPI releases: PyYAML 6.0.3, requests 2.34.2, urllib3 2.7.0 (black was already 26.5.1).
- Bump `packageManager` from pnpm 10.34.5 to 11.25.0. npm packages were already at latest.
- Add a Dependabot pip update stream targeting the `docs` branch so site dependencies get weekly PRs.

## Notes
- GitHub Actions majors, Node 24, and Python 3.13 were already current.
- CI `clang-format` stays on 16.0.6. The npm wrapper still ships clang-format 15, and jumping to 23 would reformat thousands of C++/Java files.

## Test plan
- [ ] Confirm `pnpm install` works with Corepack pnpm 11
- [ ] Confirm `python -m pip install -r requirements.txt` on Python 3.13
- [ ] Dependabot still opens npm/actions/pip PRs against main

Made with [Cursor](https://cursor.com)