### PR TITLE
ci: tighten PR bots and align clang-format with local LLVM 15

### DIFF
--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -36,7 +36,7 @@ jobs:
           GIT_BEFORE: ${{ github.event.before }}
         run: bash .github/scripts/fetch-diff-base.sh
       - name: Install clang-format
-        run: python3 -m pip install clang-format==16.0.6
+        run: python3 -m pip install clang-format==15.0.7
       - name: Check clang-format
         run: |
           set -euo pipefail

--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -36,7 +36,7 @@ jobs:
           GIT_BEFORE: ${{ github.event.before }}
         run: bash .github/scripts/fetch-diff-base.sh
       - name: Install clang-format
-        run: python3 -m pip install clang-format==15.0.7
+        run: python3 -m pip install clang-format==16.0.6
       - name: Check clang-format
         run: |
           set -euo pipefail

--- a/.github/workflows/pr-add-label.yml
+++ b/.github/workflows/pr-add-label.yml
@@ -4,11 +4,15 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
+# Labels external PRs via the GitHub API only. Do not check out PR code here.
+# Fork PRs must still run; prettier.yml is the workflow that skips forks.
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   add-label:
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     if: github.repository == 'doocs/leetcode'
     steps:

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -12,8 +12,7 @@ concurrency:
 # Fork PRs must still run so outside contributors see the guidelines.
 
 permissions:
-  contents: read
-  pull-requests: write
+  issues: write
 
 jobs:
   build:

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -2,14 +2,22 @@ name: pr-checker
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, reopened]
 
 concurrency:
   group: ${{github.workflow}} - ${{github.ref}}
   cancel-in-progress: true
 
+# Comments via the GitHub API only. Do not check out PR code here.
+# Fork PRs must still run so outside contributors see the guidelines.
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
+    if: github.repository == 'doocs/leetcode'
     runs-on: ubuntu-latest
     steps:
       - name: Check Team Membership

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -7,8 +7,6 @@ on:
 # Comments via the GitHub API only. Do not check out PR code here.
 
 permissions:
-  contents: read
-  pull-requests: write
   issues: write
 
 jobs:

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -4,13 +4,16 @@ on:
   pull_request_target:
     types: [labeled]
 
+# Comments via the GitHub API only. Do not check out PR code here.
+
 permissions:
   contents: read
+  pull-requests: write
+  issues: write
 
 jobs:
   issue-labeled:
-    permissions:
-      issues: write
+    if: github.repository == 'doocs/leetcode'
     runs-on: ubuntu-latest
     steps:
       - name: supplement

--- a/.github/workflows/starcharts.yml
+++ b/.github/workflows/starcharts.yml
@@ -5,6 +5,13 @@ on:
     - cron: "0 0/12 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   update-readme:
     name: Generate starcharts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ pnpm run setup:python     # Optional: black and the problem-sync spider
 
 GitHub Actions automatically run:
 
-- **clang-format** lint on changed C/C++/Java files (LLVM 15, same as the npm `clang-format` wrapper)
+- **clang-format** lint on changed C/C++/Java files
 - **Black** lint on changed Python files
 - **gofmt** lint on changed Go files
 - **rustfmt** lint on changed Rust files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,15 @@ This is [doocs/leetcode](https://github.com/doocs/leetcode) — a large collecti
 - **`lcs/`** — LeetCode Contest (separate series)
 - **`basic/`** — Basic algorithm implementations (sorting algorithms like BubbleSort, QuickSort, etc.)
 
+## Branch model
+
+- **`main`** — problem sources, lint tooling, and deploy workflows.
+- **`docs`** — MkDocs site engine only (`build_site.py`, `mkdocs.yml`, `hooks/`, `overrides/`). Problem pages are generated at deploy time from `main`.
+
+Deploy checks out both branches, overlays a whitelist from `docs` onto `main`, runs `python3 build_site.py`, then builds zh/en in parallel. Content pushes on `main` go through `deploy-request.yml` (about 90s quiet period, then `gh workflow run deploy.yml`). Pushes to `docs` use `.github/workflows/trigger-deploy.yml` the same way. A started `deploy.yml` run is not cancelled.
+
+Dependabot updates npm, GitHub Actions, and pip on `main`, and pip on `docs`.
+
 ## Development Workflow
 
 ### Adding a New Solution
@@ -68,12 +77,12 @@ pnpm run setup:python     # Optional: black and the problem-sync spider
 
 GitHub Actions automatically run:
 
-- **clang-format** lint on changed C/C++/Java files
+- **clang-format** lint on changed C/C++/Java files (LLVM 15, same as the npm `clang-format` wrapper)
 - **Black** lint on changed Python files
 - **gofmt** lint on changed Go files
 - **rustfmt** lint on changed Rust files
-- **Prettier** on JS/TS/PHP/SQL/Markdown files (auto-format same-repo PRs; `--check` on all PRs)
-- **Deploy** overlays the `docs` branch site engine onto `main` content (whitelist only) and builds GitHub Pages. Content pushes wait ~90s and coalesce; a started site build is not cancelled.
+- **Prettier** on JS/TS/PHP/SQL/Markdown files (auto-format same-repo PRs to `main`; `--check` on all PRs)
+- **Deploy** as described under Branch model. Same-repo Prettier uses `pull_request_target` and skips forks so it never installs untrusted `package.json`.
 
 ## Solution Patterns
 
@@ -81,7 +90,7 @@ GitHub Actions automatically run:
 - Go solutions include `package main` header (added/removed by formatting script)
 - PHP solutions include `<?php` header (added/removed by formatting script)
 - SQL solutions uppercase built-in function names (handled by `run_format.py`)
-- C# solutions contributed by [@kfstorm](https://github.com/kfstorm)
+- C# solutions contributed by [@kfstorm](https://github.com/kfstorm); match existing brace style and do not add CSharpier
 
 ## Key Conventions
 


### PR DESCRIPTION
## Summary
- Align CI clang-format to LLVM 15.0.7 so it matches the npm wrapper used by lint-staged.
- Give PR bot workflows least-privilege permissions and a repository guard. They stay API-only so fork PRs still get labels and guideline comments.
- Add concurrency on starcharts. Document the main/docs deploy split in `AGENTS.md`.

## Test plan
- [ ] Open a same-repo PR that touches a `.cpp` file and confirm clang-format 15 runs
- [ ] Open or reopen an external PR and confirm the guideline comment still posts
- [ ] Confirm labels still apply on fork PRs

Made with [Cursor](https://cursor.com)