### PR TITLE
build: use pip clang-format 23 for local and CI

### DIFF
--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -36,7 +36,7 @@ jobs:
           GIT_BEFORE: ${{ github.event.before }}
         run: bash .github/scripts/fetch-diff-base.sh
       - name: Install clang-format
-        run: python3 -m pip install clang-format==16.0.6
+        run: python3 -m pip install clang-format==23.1.0
       - name: Check clang-format
         run: |
           set -euo pipefail

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,8 @@ pnpm exec prettier --write "**/*.{js,ts,php,sql,md}"
 # Python
 node scripts/run-py.js -m black -S <file>
 
-# C/C++/Java
-pnpm exec clang-format -i --style=file <file>
+# C/C++/Java (LLVM 23 via pip clang-format)
+node scripts/run-py.js run_format.py --clang-format <file>
 
 # Go (adds/removes the `package main` header used by Solution.go files)
 node scripts/run-py.js run_format.py --gofmt <file>
@@ -68,7 +68,7 @@ pnpm run setup:python     # Optional: black and the problem-sync spider
 
 GitHub Actions automatically run:
 
-- **clang-format** lint on changed C/C++/Java files
+- **clang-format** lint on changed C/C++/Java files (LLVM 23, same pip package as local)
 - **Black** lint on changed Python files
 - **gofmt** lint on changed Go files
 - **rustfmt** lint on changed Rust files

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@commitlint/cli": "^21.2.2",
     "@commitlint/config-conventional": "^21.2.2",
     "@prettier/plugin-php": "^0.25.0",
-    "clang-format": "^1.8.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.4.1",
     "prettier": "^3.9.6",
@@ -16,7 +15,7 @@
   "lint-staged": {
     "*.{js,ts,php,sql,md}": "prettier --write",
     "*.py": "node scripts/run-py.js -m black -S",
-    "*.{c,cpp,java}": "pnpm exec clang-format -i --style=file",
+    "*.{c,cpp,java}": "node scripts/run-py.js run_format.py --clang-format",
     "*.go": "node scripts/run-py.js run_format.py --gofmt",
     "*.rs": "rustfmt"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@prettier/plugin-php':
         specifier: ^0.25.0
         version: 0.25.0(prettier@3.9.6)
-      clang-format:
-        specifier: ^1.8.0
-        version: 1.8.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -282,29 +279,13 @@ packages:
     resolution: {integrity: sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==}
     engines: {node: '>=22'}
 
-  async@3.2.6:
-    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
-
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  brace-expansion@1.1.18:
-    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
-
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  clang-format@1.8.0:
-    resolution: {integrity: sha512-pK8gzfu55/lHzIpQ1givIbWfn3eXnU7SfxqIwVgnn5jEM6j4ZJYjpFqFs4iSBPNedzRMmfjYjuQhu657WAXHXw==}
-    hasBin: true
-
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   conventional-changelog-angular@9.4.0:
     resolution: {integrity: sha512-HdxRxuS8bBXVIuo4V82gvSwAXT0vYQUizrjs/izmPg5JdDstr8v8I5hduGL3iQbG+o310dUDxC4+LetuS5hu9w==}
@@ -346,10 +327,6 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
-  es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
   es-toolkit@1.52.0:
     resolution: {integrity: sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==}
 
@@ -363,12 +340,6 @@ packages:
   fast-uri@3.1.6:
     resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
-  function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -377,17 +348,9 @@ packages:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
   global-directory@5.0.0:
     resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
     engines: {node: '>=20'}
-
-  hasown@2.0.4:
-    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
-    engines: {node: '>= 0.4'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -398,23 +361,12 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
   ini@6.0.0:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-
-  is-core-module@2.16.2:
-    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
-    engines: {node: '>= 0.4'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -448,12 +400,6 @@ packages:
     engines: {node: '>=22.22.1'}
     hasBin: true
 
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -461,13 +407,6 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
-
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
-
-  path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   php-parser@3.7.0:
     resolution: {integrity: sha512-JRc1t78GZAEa+MuzVC5A5RJS1NDFTS4UnprUEu/NnsN9cyHbGZLUqghO9IQZUSCay62HYQiWd3PxyWAEF45zmA==}
@@ -499,11 +438,6 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
-  resolve@1.22.12:
-    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
-    engines: {node: '>= 0.4'}
-    hasBin: true
-
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -528,10 +462,6 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
-  supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -547,9 +477,6 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -788,30 +715,13 @@ snapshots:
 
   argue-cli@3.1.0: {}
 
-  async@3.2.6: {}
-
-  balanced-match@1.0.2: {}
-
-  brace-expansion@1.1.18:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
   callsites@3.1.0: {}
-
-  clang-format@1.8.0:
-    dependencies:
-      async: 3.2.6
-      glob: 7.2.3
-      resolve: 1.22.12
 
   cliui@9.0.1:
     dependencies:
       string-width: 7.2.0
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
-
-  concat-map@0.0.1: {}
 
   conventional-changelog-angular@9.4.0:
     dependencies:
@@ -850,8 +760,6 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
-  es-errors@1.3.0: {}
-
   es-toolkit@1.52.0: {}
 
   escalade@3.2.0: {}
@@ -860,30 +768,13 @@ snapshots:
 
   fast-uri@3.1.6: {}
 
-  fs.realpath@1.0.0: {}
-
-  function-bind@1.1.2: {}
-
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
 
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.5
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-
   global-directory@5.0.0:
     dependencies:
       ini: 6.0.0
-
-  hasown@2.0.4:
-    dependencies:
-      function-bind: 1.1.2
 
   husky@9.1.7: {}
 
@@ -892,20 +783,9 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-
-  inherits@2.0.4: {}
-
   ini@6.0.0: {}
 
   is-arrayish@0.2.1: {}
-
-  is-core-module@2.16.2:
-    dependencies:
-      hasown: 2.0.4
 
   is-plain-obj@4.1.0: {}
 
@@ -933,14 +813,6 @@ snapshots:
     optionalDependencies:
       yaml: 2.9.0
 
-  minimatch@3.1.5:
-    dependencies:
-      brace-expansion: 1.1.18
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
-
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -951,10 +823,6 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-
-  path-is-absolute@1.0.1: {}
-
-  path-parse@1.0.7: {}
 
   php-parser@3.7.0: {}
 
@@ -974,13 +842,6 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
-
-  resolve@1.22.12:
-    dependencies:
-      es-errors: 1.3.0
-      is-core-module: 2.16.2
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
 
   semver@7.8.5: {}
 
@@ -1002,8 +863,6 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.3.0
-
-  supports-preserve-symlinks-flag@1.0.0: {}
 
   tinyexec@1.3.0: {}
 
@@ -1037,8 +896,6 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
-
-  wrappy@1.0.2: {}
 
   y18n@5.0.8: {}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black==26.5.1
+clang-format==23.1.0
 PyYAML==6.0.3
 requests==2.34.2
 urllib3==2.7.0

--- a/run_format.py
+++ b/run_format.py
@@ -305,7 +305,7 @@ def format_inline_code(path: str):
                         remove_header(file)
                 else:
                     subprocess.check_call(
-                        ["npx", "clang-format", "-i", "--style=file", file]
+                        [clang_format_bin(), "-i", "--style=file", file]
                     )
                 with open(file, "r", encoding="utf-8") as f:
                     new_block = f.read()
@@ -357,7 +357,7 @@ def run():
         if add_header(path):
             headered.append(path)
         if any(path.endswith(suf) for suf in ["c", "cpp", "java"]):
-            subprocess.check_call(["npx", "clang-format", "-i", "--style=file", path])
+            subprocess.check_call([clang_format_bin(), "-i", "--style=file", path])
 
     subprocess.check_call(["npx", "prettier", "--write", "**/*.{js,ts,php,sql,md}"])
     subprocess.check_call(["gofmt", "-w", "."])
@@ -367,6 +367,18 @@ def run():
         remove_header(path)
     for path in paths:
         format_inline_code(path)
+
+
+def clang_format_bin() -> str:
+    from clang_format import get_executable
+
+    return get_executable("clang-format")
+
+
+def format_clang_files(paths: List[str]) -> None:
+    cmd = clang_format_bin()
+    for path in paths:
+        subprocess.check_call([cmd, "-i", "--style=file", path])
 
 
 def format_go_files(paths: List[str]) -> None:
@@ -444,10 +456,12 @@ if __name__ == "__main__":
         format_go_files(args[1:])
     elif args[:1] == ["--check-gofmt"]:
         check_gofmt(args[1:])
+    elif args[:1] == ["--clang-format"]:
+        format_clang_files(args[1:])
     elif args:
         print(
             "usage: node scripts/run-py.js run_format.py "
-            "[--gofmt FILE ...] [--check-gofmt]"
+            "[--gofmt FILE ...] [--check-gofmt] [--clang-format FILE ...]"
         )
         raise SystemExit(2)
     else:

--- a/run_format.py
+++ b/run_format.py
@@ -353,11 +353,13 @@ def run():
     paths = find_all_paths()
 
     headered = []
+    clang_paths = []
     for path in paths:
         if add_header(path):
             headered.append(path)
         if any(path.endswith(suf) for suf in ["c", "cpp", "java"]):
-            subprocess.check_call([clang_format_bin(), "-i", "--style=file", path])
+            clang_paths.append(path)
+    format_clang_files(clang_paths)
 
     subprocess.check_call(["npx", "prettier", "--write", "**/*.{js,ts,php,sql,md}"])
     subprocess.check_call(["gofmt", "-w", "."])
@@ -369,16 +371,29 @@ def run():
         format_inline_code(path)
 
 
-def clang_format_bin() -> str:
-    from clang_format import get_executable
+_clang_format_exe = None
 
-    return get_executable("clang-format")
+
+def clang_format_bin() -> str:
+    global _clang_format_exe
+    if _clang_format_exe:
+        return _clang_format_exe
+    try:
+        from clang_format import get_executable
+    except ImportError as exc:
+        raise SystemExit(
+            "clang-format is not installed. Run: pnpm run setup:python"
+        ) from exc
+    _clang_format_exe = get_executable("clang-format")
+    return _clang_format_exe
 
 
 def format_clang_files(paths: List[str]) -> None:
+    if not paths:
+        return
     cmd = clang_format_bin()
-    for path in paths:
-        subprocess.check_call([cmd, "-i", "--style=file", path])
+    for i in range(0, len(paths), 64):
+        subprocess.check_call([cmd, "-i", "--style=file", *paths[i : i + 64]])
 
 
 def format_go_files(paths: List[str]) -> None:


### PR DESCRIPTION
## Summary
- npm `clang-format` 1.8.0 is stuck on LLVM 15. Local lint-staged and `run_format.py` now use the PyPI wheel `clang-format==23.1.0`.
- CI installs the same 23.1.0 pin. `pnpm run setup:python` installs it via `requirements.txt`.
- Existing C/C++/Java solutions are almost all already 23-clean. CI still only checks changed files, so this does not reformat the tree.

## Test plan
- [ ] `pnpm run setup:python` then edit a `Solution.cpp` and confirm pre-commit uses clang-format 23
- [ ] Open a PR that touches one Java/C++ file and confirm the linter installs 23.1.0
- [ ] `node scripts/run-py.js run_format.py --clang-format <file>` matches CI

Made with [Cursor](https://cursor.com)