### PR TITLE
ci: publish the built site to Gitee pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -272,3 +272,41 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+  publish-gitee:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Download Chinese site
+        uses: actions/download-artifact@v8
+        with:
+          name: site-zh
+          path: site
+
+      - name: Download English site
+        uses: actions/download-artifact@v8
+        with:
+          name: site-en
+          path: site/en
+
+      - name: Push orphan pages branch to Gitee
+        env:
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GITEE_TOKEN}" ]; then
+            echo "GITEE_TOKEN secret is not set."
+            exit 1
+          fi
+          cd site
+          touch .nojekyll
+          git init
+          git checkout --orphan pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "deploy: ${GITHUB_SHA}"
+          git push -f "https://oauth2:${GITEE_TOKEN}@gitee.com/Doocs/leetcode.git" HEAD:pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -309,4 +309,10 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "deploy: ${GITHUB_SHA}"
-          git push -f "https://oauth2:${GITEE_TOKEN}@gitee.com/Doocs/leetcode.git" HEAD:pages
+
+          ASKPASS="$(mktemp)"
+          trap 'rm -f "$ASKPASS"' EXIT
+          printf '%s\n' '#!/bin/sh' 'echo "$GITEE_TOKEN"' > "$ASKPASS"
+          chmod 700 "$ASKPASS"
+          GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0 \
+            git push -f https://oauth2@gitee.com/Doocs/leetcode.git HEAD:pages


### PR DESCRIPTION
## Summary

- Store the Gitee repo token as the `GITEE_TOKEN` Actions secret (not in the repo).
- After the site build, push an orphan `pages` branch only to `gitee.com/Doocs/leetcode`.
- Do not create that branch on GitHub. Existing GitHub Pages deploy is unchanged.

## Test plan

- [ ] Confirm `GITEE_TOKEN` exists under repo Settings → Secrets → Actions
- [ ] Merge this PR (pushing `deploy.yml` on main starts a deploy)
- [ ] Confirm `publish-gitee` force-pushes `pages` to Gitee only
- [ ] Confirm GitHub has no `pages` branch
- [ ] On Gitee: 服务 → Pages, pick the `pages` branch and `/`

Made with [Cursor](https://cursor.com)