### PR TITLE
ci: silence the Material MkDocs 2.0 build warning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,6 +146,7 @@ jobs:
       - name: Build ${{ matrix.lang }} site
         env:
           MKDOCS_API_KEYS: ${{ secrets.MKDOCS_API_KEYS }}
+          NO_MKDOCS_2_WARNING: '1'
         run: mkdocs build -f ${{ matrix.config }}
 
       - name: Upload ${{ matrix.lang }} site


### PR DESCRIPTION
## Summary

- Keep MkDocs 1.x (Material already pins `mkdocs<2`).
- Set `NO_MKDOCS_2_WARNING=1` on the `mkdocs build` step so deploy logs no longer print the MkDocs 2.0 notice.

## Test plan

- [ ] Merge (pushing `deploy.yml` starts a deploy)
- [ ] Confirm zh/en build logs no longer show the Material MkDocs 2.0 warning
- [ ] Confirm the site still builds

Made with [Cursor](https://cursor.com)