### PR TITLE
fix: keep file URLs intact in stay_on_page relatives

### DIFF
--- a/hooks/stay_on_page.py
+++ b/hooks/stay_on_page.py
@@ -1,5 +1,5 @@
 import re
-from posixpath import relpath
+from posixpath import dirname, relpath
 
 # Minify may strip quotes: <a href=/en/ hreflang=en>
 # Also rewrite <link rel=alternate href=/en/ hreflang=en>
@@ -43,12 +43,22 @@ def _abs_url(rel: str, *, en: bool) -> str:
 
 
 def _relative_href(from_abs: str, to_abs: str) -> str:
-    from_dir = from_abs if from_abs.endswith("/") else from_abs + "/"
-    to_dir = to_abs if to_abs.endswith("/") else to_abs + "/"
-    rel = relpath(to_dir, from_dir)
+    to_is_dir = to_abs.endswith("/")
+    if from_abs.endswith("/"):
+        start = from_abs.rstrip("/") or "/"
+    else:
+        start = dirname(from_abs) or "/"
+    target = to_abs.rstrip("/") if to_is_dir else to_abs
+    if target == "":
+        target = "/"
+    rel = relpath(target, start)
+    if to_is_dir:
+        if rel in (".", ""):
+            return "./"
+        return rel if rel.endswith("/") else f"{rel}/"
     if rel in (".", ""):
-        return "./"
-    return rel if rel.endswith("/") else f"{rel}/"
+        return to_abs.rsplit("/", 1)[-1] or "./"
+    return rel
 
 
 def on_post_page(output, page, config):


### PR DESCRIPTION
## Summary

- Addresses Copilot on #5428: `_relative_href` treated every path as a directory, so `404.html` became `404.html/`.
- Directory pages (`/lc/1/`) still get a trailing slash. File pages keep the filename.
- On Gitee, a 404 language switch with `../en/404.html/` would leave `/leetcode/` and hit `doocs.gitee.io/en/404.html/`.

## Test plan

- [x] Existing zh/en home and problem relative hrefs unchanged
- [x] `404.html` → `en/404.html` (zh) and `../404.html` (en)
- [ ] After deploy, `/404.html` language switch stays under the site prefix on Gitee

Made with [Cursor](https://cursor.com)