### PR TITLE
perf: drop Google Fonts and use system fonts

### DIFF
--- a/mkdocs-en.yml
+++ b/mkdocs-en.yml
@@ -7,9 +7,7 @@ copyright: Copyright &copy; 2026 <a href="https://github.com/doocs">Doocs</a><br
 theme:
   favicon: favicon.ico
   language: en
-  font:
-    text: Roboto
-    code: Roboto Mono
+  font: false
 extra:
   analytics:
     provider: google

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,9 +26,8 @@ theme:
     # - navigation.expand
     - navigation.footer
     - navigation.indexes
-    # - navigation.instant
-    # - navigation.instant.prefetch
-    # - navigation.instant.progress
+    - navigation.instant
+    - navigation.instant.progress
     - navigation.prune
     # sections would mark each 100-problem range as is_section and skip prune
     # - navigation.sections
@@ -44,6 +43,7 @@ theme:
   icon:
     repo: fontawesome/brands/github
   language: zh
+  font: false
   palette:
     - media: "(prefers-color-scheme)"
       toggle:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,8 +26,9 @@ theme:
     # - navigation.expand
     - navigation.footer
     - navigation.indexes
-    - navigation.instant
-    - navigation.instant.progress
+    # - navigation.instant
+    # - navigation.instant.prefetch
+    # - navigation.instant.progress
     - navigation.prune
     # sections would mark each 100-problem range as is_section and skip prune
     # - navigation.sections


### PR DESCRIPTION
## Summary

- Set `theme.font: false` on zh and en so Material does not load Roboto from Google Fonts (render-blocking in mainland China).
- Do **not** enable `navigation.instant` — full page loads stay as they are.

## Test plan

- [ ] After deploy, View Source / Network: no `fonts.googleapis.com` or `fonts.gstatic.com`
- [ ] Clicking between problem pages still does a normal full navigation
- [ ] Comments (giscus) and MathJax still work as before