### PR TITLE
fix: harden homepage star geo map markup

### DIFF
--- a/docs-en/index.md
+++ b/docs-en/index.md
@@ -35,10 +35,11 @@ This project contains solutions for problems from LeetCode, "Coding Interviews (
 </p>
 
 <p align="center">
-  <a href="https://next.ossinsight.io/widgets/official/analyze-repo-stars-map?repo_id=149001365&activity=stars" target="_blank">
+  <!-- off-glb skips mkdocs-glightbox so it does not unwrap this <picture> -->
+  <a href="https://next.ossinsight.io/widgets/official/analyze-repo-stars-map?repo_id=149001365&activity=stars" target="_blank" rel="noopener noreferrer">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://next.ossinsight.io/widgets/official/analyze-repo-stars-map/thumbnail.png?repo_id=149001365&activity=stars&image_size=auto&color_scheme=dark" width="721" height="auto">
-      <img class="off-glb" alt="Star Geographical Distribution of doocs/leetcode" src="https://next.ossinsight.io/widgets/official/analyze-repo-stars-map/thumbnail.png?repo_id=149001365&activity=stars&image_size=auto&color_scheme=light" width="721" height="auto">
+      <source media="(prefers-color-scheme: dark)" srcset="https://next.ossinsight.io/widgets/official/analyze-repo-stars-map/thumbnail.png?repo_id=149001365&activity=stars&image_size=auto&color_scheme=dark">
+      <img class="off-glb" alt="Star Geographical Distribution of doocs/leetcode" src="https://next.ossinsight.io/widgets/official/analyze-repo-stars-map/thumbnail.png?repo_id=149001365&activity=stars&image_size=auto&color_scheme=light" width="721">
     </picture>
   </a>
 </p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,10 +35,11 @@ hide:
 </p>
 
 <p align="center">
-  <a href="https://next.ossinsight.io/widgets/official/analyze-repo-stars-map?repo_id=149001365&activity=stars" target="_blank">
+  <!-- off-glb skips mkdocs-glightbox so it does not unwrap this <picture> -->
+  <a href="https://next.ossinsight.io/widgets/official/analyze-repo-stars-map?repo_id=149001365&activity=stars" target="_blank" rel="noopener noreferrer">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://next.ossinsight.io/widgets/official/analyze-repo-stars-map/thumbnail.png?repo_id=149001365&activity=stars&image_size=auto&color_scheme=dark" width="721" height="auto">
-      <img class="off-glb" alt="Star Geographical Distribution of doocs/leetcode" src="https://next.ossinsight.io/widgets/official/analyze-repo-stars-map/thumbnail.png?repo_id=149001365&activity=stars&image_size=auto&color_scheme=light" width="721" height="auto">
+      <source media="(prefers-color-scheme: dark)" srcset="https://next.ossinsight.io/widgets/official/analyze-repo-stars-map/thumbnail.png?repo_id=149001365&activity=stars&image_size=auto&color_scheme=dark">
+      <img class="off-glb" alt="Star Geographical Distribution of doocs/leetcode" src="https://next.ossinsight.io/widgets/official/analyze-repo-stars-map/thumbnail.png?repo_id=149001365&activity=stars&image_size=auto&color_scheme=light" width="721">
     </picture>
   </a>
 </p>


### PR DESCRIPTION
## Summary
- Follow-up to Copilot review on #5434 (already merged).
- Add `rel="noopener noreferrer"` on the geo map `target="_blank"` link.
- Drop invalid `height="auto"` and `width`/`height` on `<source>`; keep a valid `width="721"` on the image.
- Document why `off-glb` is required so GLightbox does not unwrap `<picture>`.

## Test plan
- [ ] After deploy, open https://leetcode.doocs.org/ and confirm the geo map is still centered
- [ ] Check the English homepage the same way
- [ ] Click the geo map — it should still open OSS Insight in a new tab
- [ ] Confirm dark/light `<picture>` sources still switch with the site theme
