### PR TITLE
ci: stop merged PRs from cancelling main linters

### DIFF
--- a/.github/workflows/black-lint.yml
+++ b/.github/workflows/black-lint.yml
@@ -16,8 +16,7 @@ on:
       - .github/scripts/fetch-diff-base.sh
 
 concurrency:
-  # PR number, not github.ref: a merged PR's closed event resolves ref to main
-  # and would cancel the merge-commit push under cancel-in-progress.
+  # Prefer PR number: github.ref can be the base branch and collide with push.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/black-lint.yml
+++ b/.github/workflows/black-lint.yml
@@ -16,7 +16,9 @@ on:
       - .github/scripts/fetch-diff-base.sh
 
 concurrency:
-  group: ${{ github.workflow }} - ${{ github.ref }}
+  # PR number, not github.ref: a merged PR's closed event resolves ref to main
+  # and would cancel the merge-commit push under cancel-in-progress.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -20,8 +20,7 @@ on:
       - .github/scripts/fetch-diff-base.sh
 
 concurrency:
-  # PR number, not github.ref: a merged PR's closed event resolves ref to main
-  # and would cancel the merge-commit push under cancel-in-progress.
+  # Prefer PR number: github.ref can be the base branch and collide with push.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -20,7 +20,9 @@ on:
       - .github/scripts/fetch-diff-base.sh
 
 concurrency:
-  group: ${{ github.workflow }} - ${{ github.ref }}
+  # PR number, not github.ref: a merged PR's closed event resolves ref to main
+  # and would cancel the merge-commit push under cancel-in-progress.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -20,8 +20,7 @@ on:
     - cron: '00 23 * * 0'
 
 concurrency:
-  # PR number, not github.ref: a merged PR's closed event resolves ref to main
-  # and would cancel the merge-commit push under cancel-in-progress.
+  # Prefer PR number: github.ref can be the base branch and collide with push.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -20,7 +20,9 @@ on:
     - cron: '00 23 * * 0'
 
 concurrency:
-  group: ${{github.workflow}} - ${{github.ref}}
+  # PR number, not github.ref: a merged PR's closed event resolves ref to main
+  # and would cancel the merge-commit push under cancel-in-progress.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gofmt-lint.yml
+++ b/.github/workflows/gofmt-lint.yml
@@ -16,8 +16,7 @@ on:
       - .github/scripts/fetch-diff-base.sh
 
 concurrency:
-  # PR number, not github.ref: a merged PR's closed event resolves ref to main
-  # and would cancel the merge-commit push under cancel-in-progress.
+  # Prefer PR number: github.ref can be the base branch and collide with push.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/gofmt-lint.yml
+++ b/.github/workflows/gofmt-lint.yml
@@ -16,7 +16,9 @@ on:
       - .github/scripts/fetch-diff-base.sh
 
 concurrency:
-  group: ${{ github.workflow }} - ${{ github.ref }}
+  # PR number, not github.ref: a merged PR's closed event resolves ref to main
+  # and would cancel the merge-commit push under cancel-in-progress.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened]
 
 concurrency:
-  group: ${{github.workflow}} - ${{github.ref}}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Comments via the GitHub API only. Do not check out PR code here.

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -16,8 +16,7 @@ on:
       - .github/scripts/fetch-diff-base.sh
 
 concurrency:
-  # PR number, not github.ref: a merged PR's closed event resolves ref to main
-  # and would cancel the merge-commit push under cancel-in-progress.
+  # Prefer PR number: github.ref can be the base branch and collide with push.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -16,7 +16,9 @@ on:
       - .github/scripts/fetch-diff-base.sh
 
 concurrency:
-  group: ${{ github.workflow }} - ${{ github.ref }}
+  # PR number, not github.ref: a merged PR's closed event resolves ref to main
+  # and would cancel the merge-commit push under cancel-in-progress.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, reopened, synchronize]
 
 concurrency:
-  group: ${{github.workflow}} - ${{github.ref}}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/rustfmt-lint.yml
+++ b/.github/workflows/rustfmt-lint.yml
@@ -14,8 +14,7 @@ on:
       - .github/scripts/fetch-diff-base.sh
 
 concurrency:
-  # PR number, not github.ref: a merged PR's closed event resolves ref to main
-  # and would cancel the merge-commit push under cancel-in-progress.
+  # Prefer PR number: github.ref can be the base branch and collide with push.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/rustfmt-lint.yml
+++ b/.github/workflows/rustfmt-lint.yml
@@ -14,7 +14,9 @@ on:
       - .github/scripts/fetch-diff-base.sh
 
 concurrency:
-  group: ${{ github.workflow }} - ${{ github.ref }}
+  # PR number, not github.ref: a merged PR's closed event resolves ref to main
+  # and would cancel the merge-commit push under cancel-in-progress.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Group workflow concurrency by pull request number instead of `github.ref`, so a merged PR's `closed` event no longer shares a group with the `push` to `main`.
- Keeps `cancel-in-progress` for same-PR updates, while merge-commit lint runs on `main` can finish.

## Test plan
- [ ] Open this PR and confirm lint workflows still cancel older runs when new commits are pushed to the same PR.
- [ ] After merge, confirm `black-linter` / `gofmt-linter` / `clang-format-linter` on `main` complete instead of showing `cancelled`.

Made with [Cursor](https://cursor.com)