### PR TITLE
fix: emit per-page hreflang without page-path sitemap 404s

### DIFF
--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -1,0 +1,20 @@
+name: docs-test
+
+on:
+  pull_request:
+    branches:
+      - docs
+  push:
+    branches:
+      - docs
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run stay_on_page tests
+        run: python -m unittest tests.test_stay_on_page -v

--- a/hooks/stay_on_page.py
+++ b/hooks/stay_on_page.py
@@ -8,7 +8,7 @@ from xml.etree import ElementTree as ET
 # <a hreflang> stays page-relative so Gitee /leetcode/ hosting works.
 # <link rel=alternate> is the current page pair for SEO. Material's
 # setupAlternate then requests sitemap.xml against that href
-# (mkdocs-material#6582, #7352); a head XHR patch rewrites those
+# (mkdocs-material#6582, #7352); rewrite_sitemap_pathname maps those
 # requests back to the language-root sitemaps.
 _HREFLANG_HREF = re.compile(
     r"""
@@ -30,27 +30,32 @@ _HEAD_END = re.compile(r"</head>", re.IGNORECASE)
 _SITEMAP_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
 _XHTML_NS = "http://www.w3.org/1999/xhtml"
 _CN_ONLY = frozenset(("lcof", "lcof2"))
+_SERIES = frozenset(
+    ("lc", "lcof", "lcof2", "lcci", "lcp", "lcs", "contest", "tags")
+)
 
-# Rewrites page-path sitemap.xml XHR to the language-root file.
+# Keep in sync with rewrite_sitemap_pathname().
 _XHR_PATCH = (
-    '<script>'
+    "<script>"
     "!function(){"
+    "function rewrite(p){"
+    "if(!/sitemap\\.xml$/i.test(p))return p;"
+    "var parts=p.split('/').filter(function(s){return s&&!/^sitemap\\.xml$/i.test(s)});"
+    "var series={lc:1,lcof:1,lcof2:1,lcci:1,lcp:1,lcs:1,contest:1,tags:1};"
+    "var en=-1;"
+    "for(var i=0;i<parts.length;i++)if(parts[i].toLowerCase()==='en'){en=i;break}"
+    "if(en>=0)return'/'+parts.slice(0,en+1).join('/')+'/sitemap.xml';"
+    "if(parts[0]&&series[parts[0]])return'/sitemap.xml';"
+    "if(parts.length>=2&&series[parts[1]])return'/'+parts[0]+'/sitemap.xml';"
+    "if(parts.length===1)return'/'+parts[0]+'/sitemap.xml';"
+    "return'/sitemap.xml'"
+    "}"
     "var n=XMLHttpRequest.prototype.open;"
     "XMLHttpRequest.prototype.open=function(m,u){"
     "var a=arguments;"
     "try{"
-    "var x=new URL(String(u),location.href),p=x.pathname;"
-    "if(/\\/sitemap\\.xml$/i.test(p)&&p!=='/sitemap.xml'&&p!=='/en/sitemap.xml'){"
-    "var i=p.indexOf('/en/');"
-    "if(i>=0)x.pathname=p.slice(0,i+4)+'sitemap.xml';"
-    "else{"
-    "var s=p.replace(/\\/sitemap\\.xml$/i,'').split('/').filter(Boolean),"
-    "g={lc:1,lcof:1,lcof2:1,lcci:1,lcp:1,lcs:1,contest:1,tags:1};"
-    "x.pathname=s[0]&&g[s[0]]?'/sitemap.xml':"
-    "s.length>=2&&g[s[1]]?'/'+s[0]+'/sitemap.xml':'/sitemap.xml'"
-    "}"
-    "a=Array.prototype.slice.call(arguments);a[1]=x.href"
-    "}"
+    "var x=new URL(String(u),location.href),r=rewrite(x.pathname);"
+    "if(r!==x.pathname){x.pathname=r;a=Array.prototype.slice.call(arguments);a[1]=x.href}"
     "}catch(e){}"
     "return n.apply(this,a)"
     "}"
@@ -58,8 +63,28 @@ _XHR_PATCH = (
     "</script>"
 )
 
-ET.register_namespace("", _SITEMAP_NS)
-ET.register_namespace("xhtml", _XHTML_NS)
+
+def rewrite_sitemap_pathname(pathname: str) -> str:
+    raw = pathname or ""
+    if not raw.lower().endswith("sitemap.xml"):
+        return pathname
+    parts = [p for p in raw.split("/") if p and p.lower() != "sitemap.xml"]
+    en_idx = next((i for i, p in enumerate(parts) if p.lower() == "en"), -1)
+    if en_idx >= 0:
+        return "/" + "/".join(parts[: en_idx + 1]) + "/sitemap.xml"
+    if parts and parts[0] in _SERIES:
+        return "/sitemap.xml"
+    if len(parts) >= 2 and parts[1] in _SERIES:
+        return f"/{parts[0]}/sitemap.xml"
+    if len(parts) == 1:
+        return f"/{parts[0]}/sitemap.xml"
+    return "/sitemap.xml"
+
+
+def _config_get(config, key: str, default=""):
+    if isinstance(config, dict):
+        return config.get(key, default)
+    return getattr(config, key, default)
 
 
 def _page_rel(page) -> str:
@@ -70,32 +95,49 @@ def _page_rel(page) -> str:
 
 
 def _is_en_site(config) -> bool:
-    if isinstance(config, dict):
-        site_url = str(config.get("site_url") or "")
-        site_dir = str(config.get("site_dir") or "")
-    else:
-        site_url = str(getattr(config, "site_url", "") or "")
-        site_dir = str(getattr(config, "site_dir", "") or "")
-    site_url = site_url.rstrip("/")
-    site_dir = site_dir.replace("\\", "/").rstrip("/")
+    site_url = str(_config_get(config, "site_url") or "").rstrip("/")
+    site_dir = str(_config_get(config, "site_dir") or "").replace("\\", "/").rstrip("/")
     return site_url.endswith("/en") or site_dir.endswith("/en") or site_dir == "en"
 
 
 def _site_origin(config) -> str:
-    if isinstance(config, dict):
-        site_url = str(config.get("site_url") or "")
-    else:
-        site_url = str(getattr(config, "site_url", "") or "")
-    site_url = site_url.rstrip("/")
+    site_url = str(_config_get(config, "site_url") or "").rstrip("/")
     if site_url.endswith("/en"):
         site_url = site_url[:-3]
     return site_url
 
 
 def _site_dir(config) -> str:
-    if isinstance(config, dict):
-        return str(config.get("site_dir") or "")
-    return str(getattr(config, "site_dir", "") or "")
+    return str(_config_get(config, "site_dir") or "")
+
+
+def _docs_dir(config) -> Path:
+    raw = str(_config_get(config, "docs_dir") or "")
+    return Path(raw) if raw else Path()
+
+
+def _peer_docs_dir(config):
+    docs = _docs_dir(config)
+    if not docs.name:
+        return None
+    if docs.name == "docs-en" or _is_en_site(config):
+        peer = docs.parent / "docs"
+    else:
+        peer = docs.parent / "docs-en"
+    try:
+        return peer if peer.is_dir() else None
+    except OSError:
+        return None
+
+
+def _markdown_exists(docs_dir: Path, rel: str) -> bool:
+    rel = (rel or "").strip("/")
+    paths = (
+        [docs_dir / "index.md"]
+        if not rel
+        else [docs_dir / f"{rel}.md", docs_dir / rel / "index.md"]
+    )
+    return any(p.is_file() for p in paths)
 
 
 def _abs_url(rel: str, *, en: bool) -> str:
@@ -123,9 +165,22 @@ def _relative_href(from_abs: str, to_abs: str) -> str:
     return rel
 
 
-def _support_en(rel: str) -> bool:
+def _prefix_supports_en(rel: str) -> bool:
     prefix = rel.split("/", 1)[0] if rel else ""
     return prefix not in _CN_ONLY
+
+
+def _has_en_page(rel: str, config) -> bool:
+    if not _prefix_supports_en(rel):
+        return False
+    if isinstance(config, dict) and "has_en" in config:
+        return bool(config["has_en"])
+    if _is_en_site(config):
+        return True
+    peer = _peer_docs_dir(config)
+    if peer is None:
+        return True
+    return _markdown_exists(peer, rel)
 
 
 def _page_href(rel: str, *, en: bool, origin: str) -> str:
@@ -133,10 +188,10 @@ def _page_href(rel: str, *, en: bool, origin: str) -> str:
     return origin + path if origin else path
 
 
-def _hreflang_pair(rel: str, origin: str) -> list[tuple[str, str]]:
+def _hreflang_pair(rel: str, origin: str, *, has_en: bool) -> list:
     cn = _page_href(rel, en=False, origin=origin)
     links = [("zh", cn), ("x-default", cn)]
-    if _support_en(rel):
+    if has_en:
         links.insert(1, ("en", _page_href(rel, en=True, origin=origin)))
     return links
 
@@ -150,7 +205,7 @@ def _sitemap_href(config) -> str:
     return f"{origin}/sitemap.xml"
 
 
-def _inject_head(output: str, snippets: list[str]) -> str:
+def _inject_head(output: str, snippets: list) -> str:
     extra = "".join(s for s in snippets if s)
     if not extra:
         return output
@@ -168,24 +223,29 @@ def _rel_from_loc(loc: str) -> str:
     return path
 
 
-def _annotate_sitemap_url(url_el, origin: str) -> None:
+def _annotate_sitemap_url(url_el, origin: str, has_en) -> None:
     loc_el = url_el.find(f"{{{_SITEMAP_NS}}}loc")
     if loc_el is None or not (loc_el.text or "").strip():
         return
     for child in list(url_el):
         if child.tag == f"{{{_XHTML_NS}}}link":
             url_el.remove(child)
-    for lang, href in _hreflang_pair(_rel_from_loc(loc_el.text), origin):
+    rel = _rel_from_loc(loc_el.text)
+    for lang, href in _hreflang_pair(rel, origin, has_en=has_en(rel)):
         el = ET.SubElement(url_el, f"{{{_XHTML_NS}}}link")
         el.set("rel", "alternate")
         el.set("hreflang", lang)
         el.set("href", href)
 
 
-def annotate_sitemap(xml_text: str, origin: str) -> str:
+def annotate_sitemap(xml_text: str, origin: str, has_en=None) -> str:
+    ET.register_namespace("", _SITEMAP_NS)
+    ET.register_namespace("xhtml", _XHTML_NS)
+    if has_en is None:
+        has_en = _prefix_supports_en
     root = ET.fromstring(xml_text)
     for url_el in root.findall(f"{{{_SITEMAP_NS}}}url"):
-        _annotate_sitemap_url(url_el, origin)
+        _annotate_sitemap_url(url_el, origin, has_en)
     return ET.tostring(root, encoding="utf-8", xml_declaration=True).decode("utf-8")
 
 
@@ -193,13 +253,14 @@ def on_post_build(config):
     sitemap = Path(_site_dir(config)) / "sitemap.xml"
     if not sitemap.is_file():
         return
-    try:
-        sitemap.write_text(
-            annotate_sitemap(sitemap.read_text(encoding="utf-8"), _site_origin(config)),
-            encoding="utf-8",
-        )
-    except Exception as e:
-        print(f"Error in stay_on_page sitemap annotate: {e}")
+    sitemap.write_text(
+        annotate_sitemap(
+            sitemap.read_text(encoding="utf-8"),
+            _site_origin(config),
+            has_en=lambda rel: _has_en_page(rel, config),
+        ),
+        encoding="utf-8",
+    )
 
 
 def on_post_page(output, page, config):
@@ -208,7 +269,7 @@ def on_post_page(output, page, config):
 
     rel = _page_rel(page)
     here = _abs_url(rel, en=_is_en_site(config))
-    support_en = _support_en(rel)
+    support_en = _has_en_page(rel, config)
     origin = _site_origin(config)
     cn_href = _page_href(rel, en=False, origin=origin)
     en_href = _page_href(rel, en=True, origin=origin)

--- a/hooks/stay_on_page.py
+++ b/hooks/stay_on_page.py
@@ -1,10 +1,15 @@
 import re
+from pathlib import Path
 from posixpath import dirname, relpath
+from urllib.parse import urlparse
+from xml.etree import ElementTree as ET
 
 # Minify may strip quotes: <a href=/en/ hreflang=en>
 # <a hreflang> stays page-relative so Gitee /leetcode/ hosting works.
-# <link rel=alternate> stays on the language root so clients resolve
-# sitemap.xml to /sitemap.xml or /en/sitemap.xml (mkdocs-material#6582, #7352).
+# <link rel=alternate> is the current page pair for SEO. Material's
+# setupAlternate then requests sitemap.xml against that href
+# (mkdocs-material#6582, #7352); a head XHR patch rewrites those
+# requests back to the language-root sitemaps.
 _HREFLANG_HREF = re.compile(
     r"""
     (?P<prefix>
@@ -17,7 +22,44 @@ _HREFLANG_HREF = re.compile(
     """,
     re.IGNORECASE | re.VERBOSE,
 )
+_LINK_HREFLANG_EN = re.compile(
+    r"<link\b(?=[^>]*\bhreflang=(['\"]?)en\1)[^>]*>",
+    re.IGNORECASE,
+)
 _HEAD_END = re.compile(r"</head>", re.IGNORECASE)
+_SITEMAP_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
+_XHTML_NS = "http://www.w3.org/1999/xhtml"
+_CN_ONLY = frozenset(("lcof", "lcof2"))
+
+# Rewrites page-path sitemap.xml XHR to the language-root file.
+_XHR_PATCH = (
+    '<script>'
+    "!function(){"
+    "var n=XMLHttpRequest.prototype.open;"
+    "XMLHttpRequest.prototype.open=function(m,u){"
+    "var a=arguments;"
+    "try{"
+    "var x=new URL(String(u),location.href),p=x.pathname;"
+    "if(/\\/sitemap\\.xml$/i.test(p)&&p!=='/sitemap.xml'&&p!=='/en/sitemap.xml'){"
+    "var i=p.indexOf('/en/');"
+    "if(i>=0)x.pathname=p.slice(0,i+4)+'sitemap.xml';"
+    "else{"
+    "var s=p.replace(/\\/sitemap\\.xml$/i,'').split('/').filter(Boolean),"
+    "g={lc:1,lcof:1,lcof2:1,lcci:1,lcp:1,lcs:1,contest:1,tags:1};"
+    "x.pathname=s[0]&&g[s[0]]?'/sitemap.xml':"
+    "s.length>=2&&g[s[1]]?'/'+s[0]+'/sitemap.xml':'/sitemap.xml'"
+    "}"
+    "a=Array.prototype.slice.call(arguments);a[1]=x.href"
+    "}"
+    "}catch(e){}"
+    "return n.apply(this,a)"
+    "}"
+    "}()"
+    "</script>"
+)
+
+ET.register_namespace("", _SITEMAP_NS)
+ET.register_namespace("xhtml", _XHTML_NS)
 
 
 def _page_rel(page) -> str:
@@ -50,6 +92,12 @@ def _site_origin(config) -> str:
     return site_url
 
 
+def _site_dir(config) -> str:
+    if isinstance(config, dict):
+        return str(config.get("site_dir") or "")
+    return str(getattr(config, "site_dir", "") or "")
+
+
 def _abs_url(rel: str, *, en: bool) -> str:
     if en:
         return f"/en/{rel}" if rel else "/en/"
@@ -75,15 +123,22 @@ def _relative_href(from_abs: str, to_abs: str) -> str:
     return rel
 
 
-def _language_root(*, en: bool) -> str:
-    return "/en/" if en else "/"
+def _support_en(rel: str) -> bool:
+    prefix = rel.split("/", 1)[0] if rel else ""
+    return prefix not in _CN_ONLY
 
 
-def _alternate_href(*, en: bool, origin: str) -> str:
-    root = _language_root(en=en)
-    if origin:
-        return origin + root
-    return root
+def _page_href(rel: str, *, en: bool, origin: str) -> str:
+    path = _abs_url(rel, en=en)
+    return origin + path if origin else path
+
+
+def _hreflang_pair(rel: str, origin: str) -> list[tuple[str, str]]:
+    cn = _page_href(rel, en=False, origin=origin)
+    links = [("zh", cn), ("x-default", cn)]
+    if _support_en(rel):
+        links.insert(1, ("en", _page_href(rel, en=True, origin=origin)))
+    return links
 
 
 def _sitemap_href(config) -> str:
@@ -95,11 +150,56 @@ def _sitemap_href(config) -> str:
     return f"{origin}/sitemap.xml"
 
 
-def _inject_sitemap_link(output: str, href: str) -> str:
-    if re.search(r'rel=["\']?sitemap["\']?', output, re.IGNORECASE):
+def _inject_head(output: str, snippets: list[str]) -> str:
+    extra = "".join(s for s in snippets if s)
+    if not extra:
         return output
-    link = f'<link rel="sitemap" type="application/xml" title="Sitemap" href="{href}">'
-    return _HEAD_END.sub(f"{link}</head>", output, count=1)
+    return _HEAD_END.sub(f"{extra}</head>", output, count=1)
+
+
+def _rel_from_loc(loc: str) -> str:
+    path = urlparse(loc.strip()).path
+    trailing = path.endswith("/")
+    path = path.strip("/")
+    if path == "en" or path.startswith("en/"):
+        path = path[3:].lstrip("/")
+    if path and trailing:
+        return f"{path}/"
+    return path
+
+
+def _annotate_sitemap_url(url_el, origin: str) -> None:
+    loc_el = url_el.find(f"{{{_SITEMAP_NS}}}loc")
+    if loc_el is None or not (loc_el.text or "").strip():
+        return
+    for child in list(url_el):
+        if child.tag == f"{{{_XHTML_NS}}}link":
+            url_el.remove(child)
+    for lang, href in _hreflang_pair(_rel_from_loc(loc_el.text), origin):
+        el = ET.SubElement(url_el, f"{{{_XHTML_NS}}}link")
+        el.set("rel", "alternate")
+        el.set("hreflang", lang)
+        el.set("href", href)
+
+
+def annotate_sitemap(xml_text: str, origin: str) -> str:
+    root = ET.fromstring(xml_text)
+    for url_el in root.findall(f"{{{_SITEMAP_NS}}}url"):
+        _annotate_sitemap_url(url_el, origin)
+    return ET.tostring(root, encoding="utf-8", xml_declaration=True).decode("utf-8")
+
+
+def on_post_build(config):
+    sitemap = Path(_site_dir(config)) / "sitemap.xml"
+    if not sitemap.is_file():
+        return
+    try:
+        sitemap.write_text(
+            annotate_sitemap(sitemap.read_text(encoding="utf-8"), _site_origin(config)),
+            encoding="utf-8",
+        )
+    except Exception as e:
+        print(f"Error in stay_on_page sitemap annotate: {e}")
 
 
 def on_post_page(output, page, config):
@@ -108,9 +208,10 @@ def on_post_page(output, page, config):
 
     rel = _page_rel(page)
     here = _abs_url(rel, en=_is_en_site(config))
-    prefix = rel.split("/", 1)[0] if rel else ""
-    support_en = prefix not in ("lcof", "lcof2")
+    support_en = _support_en(rel)
     origin = _site_origin(config)
+    cn_href = _page_href(rel, en=False, origin=origin)
+    en_href = _page_href(rel, en=True, origin=origin)
     cn_a = _relative_href(here, _abs_url(rel, en=False))
     en_target = _abs_url(rel, en=True) if support_en else _abs_url("", en=True)
     en_a = _relative_href(here, en_target)
@@ -118,14 +219,28 @@ def on_post_page(output, page, config):
     def repl(match):
         en = match.group("lang").lower() == "en"
         if match.group("tag").lower() == "link":
-            href = _alternate_href(en=en, origin=origin)
+            href = en_href if en else cn_href
         else:
             href = en_a if en else cn_a
         return f"{match.group('prefix')}{href}{match.group('suffix')}"
 
     try:
         output = _HREFLANG_HREF.sub(repl, output)
-        return _inject_sitemap_link(output, _sitemap_href(config))
+        if not support_en:
+            output = _LINK_HREFLANG_EN.sub("", output)
+        snippets = []
+        if not re.search(r'hreflang=["\']?x-default', output, re.IGNORECASE):
+            snippets.append(
+                f'<link rel="alternate" hreflang="x-default" href="{cn_href}">'
+            )
+        if not re.search(r'rel=["\']?sitemap["\']?', output, re.IGNORECASE):
+            snippets.append(
+                '<link rel="sitemap" type="application/xml" title="Sitemap" '
+                f'href="{_sitemap_href(config)}">'
+            )
+        if "XMLHttpRequest.prototype.open" not in output:
+            snippets.append(_XHR_PATCH)
+        return _inject_head(output, snippets)
     except Exception as e:
         print(f"Error in stay_on_page hook: {e}")
         return output

--- a/tests/test_stay_on_page.py
+++ b/tests/test_stay_on_page.py
@@ -32,7 +32,7 @@ MINIFIED = (
 
 SITEMAP = """<?xml version='1.0' encoding='UTF-8'?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-<url><loc>https://leetcode.doocs.org/lc/100/</loc></url>
+<url><loc>https://leetcode.doocs.org/lc/100/</loc><lastmod>2026-09-07</lastmod></url>
 <url><loc>https://leetcode.doocs.org/lcof/3/</loc></url>
 <url><loc>https://leetcode.doocs.org/</loc></url>
 </urlset>
@@ -120,6 +120,49 @@ class RelativeHrefTest(unittest.TestCase):
 
     def test_cn_home_to_en_home(self):
         self.assertEqual(sop._relative_href("/", "/en/"), "en/")
+
+
+class RewriteSitemapPathnameTest(unittest.TestCase):
+    def test_language_roots(self):
+        self.assertEqual(sop.rewrite_sitemap_pathname("/sitemap.xml"), "/sitemap.xml")
+        self.assertEqual(sop.rewrite_sitemap_pathname("/en/sitemap.xml"), "/en/sitemap.xml")
+
+    def test_problem_and_range_paths(self):
+        self.assertEqual(sop.rewrite_sitemap_pathname("/lc/100/sitemap.xml"), "/sitemap.xml")
+        self.assertEqual(
+            sop.rewrite_sitemap_pathname("/en/lc/100/sitemap.xml"), "/en/sitemap.xml"
+        )
+        self.assertEqual(
+            sop.rewrite_sitemap_pathname("/lc/0100-0199/sitemap.xml"), "/sitemap.xml"
+        )
+        self.assertEqual(sop.rewrite_sitemap_pathname("/lcof/3/sitemap.xml"), "/sitemap.xml")
+
+    def test_gitee_subdirectory(self):
+        self.assertEqual(
+            sop.rewrite_sitemap_pathname("/leetcode/sitemap.xml"),
+            "/leetcode/sitemap.xml",
+        )
+        self.assertEqual(
+            sop.rewrite_sitemap_pathname("/leetcode/en/sitemap.xml"),
+            "/leetcode/en/sitemap.xml",
+        )
+        self.assertEqual(
+            sop.rewrite_sitemap_pathname("/leetcode/lc/100/sitemap.xml"),
+            "/leetcode/sitemap.xml",
+        )
+        self.assertEqual(
+            sop.rewrite_sitemap_pathname("/leetcode/en/lc/100/sitemap.xml"),
+            "/leetcode/en/sitemap.xml",
+        )
+
+    def test_en_is_a_path_segment(self):
+        self.assertEqual(
+            sop.rewrite_sitemap_pathname("/english/sitemap.xml"),
+            "/english/sitemap.xml",
+        )
+
+    def test_non_sitemap_unchanged(self):
+        self.assertEqual(sop.rewrite_sitemap_pathname("/lc/100/"), "/lc/100/")
 
 
 class StayOnPageTest(unittest.TestCase):
@@ -212,6 +255,51 @@ class StayOnPageTest(unittest.TestCase):
         self.assertEqual(_sitemap_hrefs(out), ["/sitemap.xml"])
         self.assertEqual(_page_sitemaps(out), [])
 
+    def test_homepage_is_language_pair(self):
+        out = self._run("", CN_CONFIG)
+        self.assertEqual(_hrefs(out, "a"), {"zh": "./", "en": "en/"})
+        self.assertEqual(
+            _hrefs(out, "link"),
+            {
+                "zh": "https://leetcode.doocs.org/",
+                "en": "https://leetcode.doocs.org/en/",
+                "x-default": "https://leetcode.doocs.org/",
+            },
+        )
+
+    def test_missing_en_page_omits_en_alternate(self):
+        cfg = {**CN_CONFIG, "has_en": False}
+        out = self._run("lc/9999/", cfg)
+        self.assertEqual(_hrefs(out, "a")["en"], "../../en/")
+        self.assertNotIn("en", _hrefs(out, "link"))
+        self.assertEqual(
+            _hrefs(out, "link")["x-default"], "https://leetcode.doocs.org/lc/9999/"
+        )
+
+    def test_peer_docs_dir_controls_en_alternate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cn_docs = root / "docs"
+            en_docs = root / "docs-en"
+            (cn_docs / "lc").mkdir(parents=True)
+            (en_docs / "lc").mkdir(parents=True)
+            (cn_docs / "lc" / "100.md").write_text("cn", encoding="utf-8")
+            (en_docs / "lc" / "100.md").write_text("en", encoding="utf-8")
+            (cn_docs / "lc" / "9999.md").write_text("cn-only", encoding="utf-8")
+            present = self._run(
+                "lc/100/",
+                {**CN_CONFIG, "docs_dir": str(cn_docs)},
+            )
+            missing = self._run(
+                "lc/9999/",
+                {**CN_CONFIG, "docs_dir": str(cn_docs)},
+            )
+        self.assertEqual(
+            _hrefs(present, "link")["en"], "https://leetcode.doocs.org/en/lc/100/"
+        )
+        self.assertNotIn("en", _hrefs(missing, "link"))
+        self.assertEqual(_hrefs(missing, "a")["en"], "../../en/")
+
     def test_range_index_is_bilingual_page_pair(self):
         out = self._run("lc/0100-0199/", CN_CONFIG)
         self.assertEqual(
@@ -249,6 +337,27 @@ class SitemapAnnotateTest(unittest.TestCase):
             _xhtml_hrefs(xml, "https://leetcode.doocs.org/")["en"],
             "https://leetcode.doocs.org/en/",
         )
+        self.assertIn("<lastmod>2026-09-07</lastmod>", xml)
+
+    def test_skips_en_when_page_missing(self):
+        xml = sop.annotate_sitemap(
+            SITEMAP,
+            "https://leetcode.doocs.org",
+            has_en=lambda rel: rel.strip("/") == "lc/100",
+        )
+        self.assertIn("https://leetcode.doocs.org/en/lc/100/", xml)
+        self.assertNotIn("https://leetcode.doocs.org/en/lcof/", xml)
+        home = _xhtml_hrefs(xml, "https://leetcode.doocs.org/")
+        self.assertNotIn("en", home)
+
+    def test_annotate_is_idempotent(self):
+        once = sop.annotate_sitemap(SITEMAP, "https://leetcode.doocs.org")
+        twice = sop.annotate_sitemap(once, "https://leetcode.doocs.org")
+        self.assertEqual(
+            _xhtml_hrefs(twice, "https://leetcode.doocs.org/lc/100/"),
+            _xhtml_hrefs(once, "https://leetcode.doocs.org/lc/100/"),
+        )
+        self.assertEqual(twice.count('hreflang="en"'), once.count('hreflang="en"'))
 
     def test_en_sitemap_pairs_back_to_cn(self):
         xml = sop.annotate_sitemap(SITEMAP_EN, "https://leetcode.doocs.org")

--- a/tests/test_stay_on_page.py
+++ b/tests/test_stay_on_page.py
@@ -1,5 +1,6 @@
 import re
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -29,11 +30,26 @@ MINIFIED = (
     "</body></html>"
 )
 
+SITEMAP = """<?xml version='1.0' encoding='UTF-8'?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>https://leetcode.doocs.org/lc/100/</loc></url>
+<url><loc>https://leetcode.doocs.org/lcof/3/</loc></url>
+<url><loc>https://leetcode.doocs.org/</loc></url>
+</urlset>
+"""
+
+SITEMAP_EN = """<?xml version='1.0' encoding='UTF-8'?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>https://leetcode.doocs.org/en/lc/100/</loc></url>
+<url><loc>https://leetcode.doocs.org/en/</loc></url>
+</urlset>
+"""
+
 
 def _hrefs(html: str, tag: str) -> dict[str, str]:
     found = {}
     for m in re.finditer(
-        rf"""<{tag}\b(?=[^>]*\bhreflang=(?P<lq>["']?)(?P<lang>zh|en)(?P=lq))"""
+        rf"""<{tag}\b(?=[^>]*\bhreflang=(?P<lq>["']?)(?P<lang>zh|en|x-default)(?P=lq))"""
         rf"""[^>]*\bhref=(?P<hq>["']?)(?P<href>[^"'\s>]*)(?P=hq)""",
         html,
         re.IGNORECASE,
@@ -51,14 +67,38 @@ def _sitemap_hrefs(html: str) -> list[str]:
 
 
 def _page_sitemaps(html: str) -> list[str]:
+    hrefs = re.findall(
+        r"""<link\b[^>]*\bhref=["']?([^"'\s>]+)""",
+        html,
+        flags=re.IGNORECASE,
+    )
     return [
-        m
-        for m in re.findall(r"[^\"'\s>]*sitemap\.xml", html, flags=re.IGNORECASE)
-        if not re.fullmatch(
-            r"https://leetcode\.doocs\.org(?:/en)?/sitemap\.xml", m, flags=re.I
+        href
+        for href in hrefs
+        if "sitemap.xml" in href.lower()
+        and not re.fullmatch(
+            r"https://leetcode\.doocs\.org(?:/en)?/sitemap\.xml", href, flags=re.I
         )
-        and m not in ("/sitemap.xml", "/en/sitemap.xml")
+        and href not in ("/sitemap.xml", "/en/sitemap.xml")
     ]
+
+
+def _xhtml_hrefs(xml: str, loc: str) -> dict[str, str]:
+    found = {}
+    for m in re.finditer(
+        rf"<url>\s*<loc>{re.escape(loc)}</loc>(.*?)</url>",
+        xml,
+        flags=re.DOTALL,
+    ):
+        for link in re.finditer(
+            r'hreflang="([^"]+)"[^>]*href="([^"]+)"|href="([^"]+)"[^>]*hreflang="([^"]+)"',
+            m.group(1),
+        ):
+            if link.group(1):
+                found[link.group(1)] = link.group(2)
+            else:
+                found[link.group(4)] = link.group(3)
+    return found
 
 
 class RelativeHrefTest(unittest.TestCase):
@@ -92,11 +132,13 @@ class StayOnPageTest(unittest.TestCase):
         self.assertEqual(
             _hrefs(out, "link"),
             {
-                "zh": "https://leetcode.doocs.org/",
-                "en": "https://leetcode.doocs.org/en/",
+                "zh": "https://leetcode.doocs.org/lc/100/",
+                "en": "https://leetcode.doocs.org/en/lc/100/",
+                "x-default": "https://leetcode.doocs.org/lc/100/",
             },
         )
         self.assertEqual(_sitemap_hrefs(out), ["https://leetcode.doocs.org/sitemap.xml"])
+        self.assertIn("XMLHttpRequest.prototype.open", out)
         self.assertEqual(_page_sitemaps(out), [])
 
     def test_bilingual_en_page(self):
@@ -105,8 +147,9 @@ class StayOnPageTest(unittest.TestCase):
         self.assertEqual(
             _hrefs(out, "link"),
             {
-                "zh": "https://leetcode.doocs.org/",
-                "en": "https://leetcode.doocs.org/en/",
+                "zh": "https://leetcode.doocs.org/lc/100/",
+                "en": "https://leetcode.doocs.org/en/lc/100/",
+                "x-default": "https://leetcode.doocs.org/lc/100/",
             },
         )
         self.assertEqual(
@@ -114,31 +157,39 @@ class StayOnPageTest(unittest.TestCase):
         )
         self.assertEqual(_page_sitemaps(out), [])
 
-    def test_lcof_has_no_en_problem(self):
+    def test_lcof_has_no_en_alternate_link(self):
         out = self._run("lcof/3/", CN_CONFIG)
         self.assertEqual(_hrefs(out, "a"), {"zh": "./", "en": "../../en/"})
+        links = _hrefs(out, "link")
+        self.assertNotIn("en", links)
         self.assertEqual(
-            _hrefs(out, "link"),
+            links,
             {
-                "zh": "https://leetcode.doocs.org/",
-                "en": "https://leetcode.doocs.org/en/",
+                "zh": "https://leetcode.doocs.org/lcof/3/",
+                "x-default": "https://leetcode.doocs.org/lcof/3/",
             },
         )
         self.assertEqual(_sitemap_hrefs(out), ["https://leetcode.doocs.org/sitemap.xml"])
         self.assertEqual(_page_sitemaps(out), [])
-        self.assertNotIn("/lcof/3/sitemap.xml", out)
+        self.assertNotIn("/lcof/3/sitemap.xml", out.split("<script>")[0])
         self.assertNotIn("./sitemap.xml", out)
 
-    def test_lcof2_has_no_en_problem(self):
+    def test_lcof2_has_no_en_alternate_link(self):
         out = self._run("lcof2/76/", CN_CONFIG)
         self.assertEqual(_hrefs(out, "a")["en"], "../../en/")
-        self.assertEqual(_hrefs(out, "link")["en"], "https://leetcode.doocs.org/en/")
+        self.assertNotIn("en", _hrefs(out, "link"))
+        self.assertEqual(
+            _hrefs(out, "link")["x-default"],
+            "https://leetcode.doocs.org/lcof2/76/",
+        )
 
     def test_minified_html(self):
         out = self._run("lc/100/", CN_CONFIG, MINIFIED)
         self.assertEqual(_hrefs(out, "a")["en"], "../../en/lc/100/")
-        self.assertEqual(_hrefs(out, "link")["en"], "https://leetcode.doocs.org/en/")
+        self.assertEqual(_hrefs(out, "link")["en"], "https://leetcode.doocs.org/en/lc/100/")
+        self.assertEqual(_hrefs(out, "link")["x-default"], "https://leetcode.doocs.org/lc/100/")
         self.assertEqual(_sitemap_hrefs(out), ["https://leetcode.doocs.org/sitemap.xml"])
+        self.assertIn("XMLHttpRequest.prototype.open", out)
 
     def test_does_not_double_inject_sitemap(self):
         html = HTML.replace(
@@ -151,17 +202,76 @@ class StayOnPageTest(unittest.TestCase):
     def test_empty_output(self):
         self.assertEqual(sop.on_post_page("", SimpleNamespace(url="lc/100/"), CN_CONFIG), "")
 
-    def test_alternate_without_origin_stays_on_language_root(self):
+    def test_alternate_without_origin_uses_root_absolute_pages(self):
         out = self._run("lcof/3/", {"site_url": "", "site_dir": "site"})
-        self.assertEqual(_hrefs(out, "link"), {"zh": "/", "en": "/en/"})
+        self.assertEqual(
+            _hrefs(out, "link"),
+            {"zh": "/lcof/3/", "x-default": "/lcof/3/"},
+        )
+        self.assertNotIn("en", _hrefs(out, "link"))
         self.assertEqual(_sitemap_hrefs(out), ["/sitemap.xml"])
         self.assertEqual(_page_sitemaps(out), [])
 
-    def test_range_index_does_not_emit_page_sitemap(self):
+    def test_range_index_is_bilingual_page_pair(self):
         out = self._run("lc/0100-0199/", CN_CONFIG)
-        self.assertEqual(_hrefs(out, "link")["zh"], "https://leetcode.doocs.org/")
-        self.assertNotIn("/lc/0100-0199/sitemap.xml", out)
+        self.assertEqual(
+            _hrefs(out, "link")["zh"], "https://leetcode.doocs.org/lc/0100-0199/"
+        )
+        self.assertEqual(
+            _hrefs(out, "link")["en"], "https://leetcode.doocs.org/en/lc/0100-0199/"
+        )
+        self.assertNotIn("/lc/0100-0199/sitemap.xml", out.split("<script>")[0])
         self.assertEqual(_page_sitemaps(out), [])
+
+
+class SitemapAnnotateTest(unittest.TestCase):
+    def test_bilingual_and_lcof_cn_sitemap(self):
+        xml = sop.annotate_sitemap(SITEMAP, "https://leetcode.doocs.org")
+        self.assertIn('xmlns:xhtml="http://www.w3.org/1999/xhtml"', xml)
+        self.assertEqual(
+            _xhtml_hrefs(xml, "https://leetcode.doocs.org/lc/100/"),
+            {
+                "zh": "https://leetcode.doocs.org/lc/100/",
+                "en": "https://leetcode.doocs.org/en/lc/100/",
+                "x-default": "https://leetcode.doocs.org/lc/100/",
+            },
+        )
+        lcof = _xhtml_hrefs(xml, "https://leetcode.doocs.org/lcof/3/")
+        self.assertNotIn("en", lcof)
+        self.assertEqual(
+            lcof,
+            {
+                "zh": "https://leetcode.doocs.org/lcof/3/",
+                "x-default": "https://leetcode.doocs.org/lcof/3/",
+            },
+        )
+        self.assertEqual(
+            _xhtml_hrefs(xml, "https://leetcode.doocs.org/")["en"],
+            "https://leetcode.doocs.org/en/",
+        )
+
+    def test_en_sitemap_pairs_back_to_cn(self):
+        xml = sop.annotate_sitemap(SITEMAP_EN, "https://leetcode.doocs.org")
+        self.assertEqual(
+            _xhtml_hrefs(xml, "https://leetcode.doocs.org/en/lc/100/"),
+            {
+                "zh": "https://leetcode.doocs.org/lc/100/",
+                "en": "https://leetcode.doocs.org/en/lc/100/",
+                "x-default": "https://leetcode.doocs.org/lc/100/",
+            },
+        )
+
+    def test_on_post_build_writes_sitemap(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "sitemap.xml"
+            path.write_text(SITEMAP, encoding="utf-8")
+            sop.on_post_build(
+                {"site_url": "https://leetcode.doocs.org", "site_dir": tmp}
+            )
+            xml = path.read_text(encoding="utf-8")
+            self.assertIn('hreflang="en"', xml)
+            self.assertIn("https://leetcode.doocs.org/en/lc/100/", xml)
+            self.assertNotIn("https://leetcode.doocs.org/en/lcof/", xml)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Point `<link rel=alternate>` at the matching problem URLs (`/lc/100/` <-> `/en/lc/100/`) and add `hreflang=x-default` to the Chinese page.
- Omit the English alternate when `docs-en` has no matching page (and always omit it for `lcof` / `lcof2`). `<a hreflang>` stays relative so Gitee `/leetcode/` still works.
- Rewrite Material sitemap XHR by path segment to the language-root sitemap (`rewrite_sitemap_pathname`, covered by unit tests).
- Annotate both language sitemaps with matching `xhtml:link`.
- Run `tests.test_stay_on_page` on docs PRs.

## Test plan
- [x] `py -3 -m unittest tests.test_stay_on_page -v`
- [ ] Merge and wait for the docs deploy.
- [ ] Open `/lc/100/` and confirm `hreflang` is the problem pair plus `x-default`.
- [ ] Open a CN-only problem (no `README_EN`) and confirm there is no English `<link rel=alternate>`.
- [ ] Open `/lcof/3/` and confirm there is no English `<link rel=alternate>`.
- [ ] Confirm Network only requests `/sitemap.xml` and `/en/sitemap.xml`, not `/lc/100/sitemap.xml`.
- [ ] Confirm language switcher still stays on the same problem, including on Gitee `/leetcode/`.