### PR TITLE
fix: lazy-load giscus and guard theme sync

### DIFF
--- a/overrides/partials/comments.html
+++ b/overrides/partials/comments.html
@@ -1,18 +1,65 @@
 {% if page.meta.comments %}
 <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
 <!-- Load client.js only after data-lang / data-theme are set, so async
-     cannot initialize giscus with the HTML defaults. -->
+     cannot initialize giscus with the HTML defaults. Replay theme on
+     iframe load: lazy frames drop postMessage until the widget exists. -->
 <script>
     (function () {
-        var lang = document.documentElement.lang === "en" ? "en" : "zh-CN"
+        var mount = document.currentScript.parentNode
         var theme = "preferred_color_scheme"
-        var palette = __md_get("__palette")
-        if (palette && typeof palette.color === "object") {
-            theme = palette.color.scheme === "slate" ? "dark" : "light"
+
+        function currentTheme() {
+            var palette = __md_get("__palette")
+            if (palette && typeof palette.color === "object") {
+                return palette.color.scheme === "slate" ? "dark" : "light"
+            }
+            return "preferred_color_scheme"
         }
 
+        function applyTheme(frame) {
+            if (!frame || !frame.contentWindow) {
+                return
+            }
+            frame.contentWindow.postMessage(
+                { giscus: { setConfig: { theme: theme } } },
+                "https://giscus.app"
+            )
+        }
+
+        function bindFrame(frame) {
+            if (!frame || frame.getAttribute("data-theme-bound")) {
+                applyTheme(frame)
+                return
+            }
+            frame.setAttribute("data-theme-bound", "1")
+            frame.addEventListener("load", function () {
+                applyTheme(frame)
+            })
+            applyTheme(frame)
+        }
+
+        function watchFrame() {
+            var found = document.querySelector(".giscus-frame")
+            if (found) {
+                bindFrame(found)
+                return
+            }
+            if (!mount || !window.MutationObserver) {
+                return
+            }
+            var observer = new MutationObserver(function () {
+                var frame = document.querySelector(".giscus-frame")
+                if (frame) {
+                    observer.disconnect()
+                    bindFrame(frame)
+                }
+            })
+            observer.observe(mount, { childList: true, subtree: true })
+        }
+
+        theme = currentTheme()
+
         var giscus = document.createElement("script")
-        giscus.src = "https://giscus.app/client.js"
         giscus.async = true
         giscus.crossOrigin = "anonymous"
         var attrs = {
@@ -26,13 +73,15 @@
             "data-emit-metadata": "0",
             "data-input-position": "top",
             "data-theme": theme,
-            "data-lang": lang,
+            "data-lang": document.documentElement.lang === "en" ? "en" : "zh-CN",
             "data-loading": "lazy"
         }
         Object.keys(attrs).forEach(function (key) {
             giscus.setAttribute(key, attrs[key])
         })
-        document.currentScript.parentNode.insertBefore(giscus, document.currentScript)
+        giscus.src = "https://giscus.app/client.js"
+        mount.insertBefore(giscus, document.currentScript)
+        watchFrame()
 
         document.addEventListener("DOMContentLoaded", function () {
             var ref = document.querySelector("[data-md-component=palette]")
@@ -40,19 +89,9 @@
                 return
             }
             ref.addEventListener("change", function () {
-                var nextPalette = __md_get("__palette")
-                if (!nextPalette || typeof nextPalette.color !== "object") {
-                    return
-                }
-                var nextTheme = nextPalette.color.scheme === "slate" ? "dark" : "light"
-                giscus.setAttribute("data-theme", nextTheme)
-                var frame = document.querySelector(".giscus-frame")
-                if (frame && frame.contentWindow) {
-                    frame.contentWindow.postMessage(
-                        { giscus: { setConfig: { theme: nextTheme } } },
-                        "https://giscus.app"
-                    )
-                }
+                theme = currentTheme()
+                giscus.setAttribute("data-theme", theme)
+                bindFrame(document.querySelector(".giscus-frame"))
             })
         })
     })()

--- a/overrides/partials/comments.html
+++ b/overrides/partials/comments.html
@@ -1,60 +1,60 @@
 {% if page.meta.comments %}
 <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
-<script src="https://giscus.app/client.js"
-    data-repo="doocs/leetcode"
-    data-repo-id="MDEwOlJlcG9zaXRvcnkxNDkwMDEzNjU="
-    data-category="Announcements"
-    data-category-id="DIC_kwDOCOGUlc4CZmhe"
-    data-mapping="pathname"
-    data-strict="1"
-    data-reactions-enabled="1"
-    data-emit-metadata="0"
-    data-input-position="top"
-    data-theme="preferred_color_scheme"
-    data-lang="zh-CN"
-    data-loading="lazy"
-    crossorigin="anonymous"
-    async>
-</script>
-
-<!-- Synchronize giscus theme with palette -->
+<!-- Load client.js only after data-lang / data-theme are set, so async
+     cannot initialize giscus with the HTML defaults. -->
 <script>
-    var giscus = document.querySelector("script[src*=giscus]")
-
-    /* Set language on initial load */
-    var lang = document.querySelector("html").lang
-    const dataLang = lang === "en" ? "en" : "zh-CN"
-    giscus.setAttribute("data-lang", dataLang)
-
-    /* Set palette on initial load */
-    var palette = __md_get("__palette")
-    if (palette && typeof palette.color === "object") {
-        var theme = palette.color.scheme === "slate" ? "dark" : "light"
-        giscus.setAttribute("data-theme", theme) // (1)!
-    }
-
-    /* Register event handlers after documented loaded */
-    document.addEventListener("DOMContentLoaded", function () {
-        var ref = document.querySelector("[data-md-component=palette]")
-        if (!ref) {
-            return
+    (function () {
+        var lang = document.documentElement.lang === "en" ? "en" : "zh-CN"
+        var theme = "preferred_color_scheme"
+        var palette = __md_get("__palette")
+        if (palette && typeof palette.color === "object") {
+            theme = palette.color.scheme === "slate" ? "dark" : "light"
         }
-        ref.addEventListener("change", function () {
-            var palette = __md_get("__palette")
-            if (palette && typeof palette.color === "object") {
-                var theme = palette.color.scheme === "slate" ? "dark" : "light"
 
-                /* Instruct giscus to change theme */
-                var frame = document.querySelector(".giscus-frame")
-                if (!frame || !frame.contentWindow) {
+        var giscus = document.createElement("script")
+        giscus.src = "https://giscus.app/client.js"
+        giscus.async = true
+        giscus.crossOrigin = "anonymous"
+        var attrs = {
+            "data-repo": "doocs/leetcode",
+            "data-repo-id": "MDEwOlJlcG9zaXRvcnkxNDkwMDEzNjU=",
+            "data-category": "Announcements",
+            "data-category-id": "DIC_kwDOCOGUlc4CZmhe",
+            "data-mapping": "pathname",
+            "data-strict": "1",
+            "data-reactions-enabled": "1",
+            "data-emit-metadata": "0",
+            "data-input-position": "top",
+            "data-theme": theme,
+            "data-lang": lang,
+            "data-loading": "lazy"
+        }
+        Object.keys(attrs).forEach(function (key) {
+            giscus.setAttribute(key, attrs[key])
+        })
+        document.currentScript.parentNode.insertBefore(giscus, document.currentScript)
+
+        document.addEventListener("DOMContentLoaded", function () {
+            var ref = document.querySelector("[data-md-component=palette]")
+            if (!ref) {
+                return
+            }
+            ref.addEventListener("change", function () {
+                var nextPalette = __md_get("__palette")
+                if (!nextPalette || typeof nextPalette.color !== "object") {
                     return
                 }
-                frame.contentWindow.postMessage(
-                    { giscus: { setConfig: { theme } } },
-                    "https://giscus.app"
-                )
-            }
+                var nextTheme = nextPalette.color.scheme === "slate" ? "dark" : "light"
+                giscus.setAttribute("data-theme", nextTheme)
+                var frame = document.querySelector(".giscus-frame")
+                if (frame && frame.contentWindow) {
+                    frame.contentWindow.postMessage(
+                        { giscus: { setConfig: { theme: nextTheme } } },
+                        "https://giscus.app"
+                    )
+                }
+            })
         })
-    })
+    })()
 </script>
 {% endif %}

--- a/overrides/partials/comments.html
+++ b/overrides/partials/comments.html
@@ -12,6 +12,7 @@
     data-input-position="top"
     data-theme="preferred_color_scheme"
     data-lang="zh-CN"
+    data-loading="lazy"
     crossorigin="anonymous"
     async>
 </script>
@@ -35,6 +36,9 @@
     /* Register event handlers after documented loaded */
     document.addEventListener("DOMContentLoaded", function () {
         var ref = document.querySelector("[data-md-component=palette]")
+        if (!ref) {
+            return
+        }
         ref.addEventListener("change", function () {
             var palette = __md_get("__palette")
             if (palette && typeof palette.color === "object") {
@@ -42,6 +46,9 @@
 
                 /* Instruct giscus to change theme */
                 var frame = document.querySelector(".giscus-frame")
+                if (!frame || !frame.contentWindow) {
+                    return
+                }
                 frame.contentWindow.postMessage(
                     { giscus: { setConfig: { theme } } },
                     "https://giscus.app"


### PR DESCRIPTION
## Summary
- Add `data-loading=lazy` so the comments iframe waits until it is near the viewport.
- Keep pathname + strict + Announcements unchanged.
- Skip theme `postMessage` when the palette control or giscus iframe is not ready.

## Test plan
- [ ] Open a problem page with comments and confirm the giscus iframe is not requested until you scroll near the comments section.
- [ ] Confirm an un-commented page still shows the giscus form (404 on discussions search is expected).
- [ ] Toggle light/dark before and after the iframe loads; the page should not throw.
- [ ] Leave a test comment or just confirm the login/comment box still appears.

Made with [Cursor](https://cursor.com)