### PR TITLE
perf: skip unused MathJax and stub sitemap XHRs

### DIFF
--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Run stay_on_page tests
-        run: python -m unittest tests.test_stay_on_page -v
+      - name: Run docs hook tests
+        run: python -m unittest tests.test_stay_on_page tests.test_conditional_mathjax -v

--- a/hooks/conditional_mathjax.py
+++ b/hooks/conditional_mathjax.py
@@ -1,0 +1,20 @@
+import re
+
+# pymdownx.arithmatex wraps formulas in class="arithmatex".
+# The MathJax config script also contains the string "arithmatex", so
+# only look at markup classes — not a raw substring search.
+_ARITHMATEX = re.compile(
+    r"""<[a-z][^>]*\bclass=(['\"]?)[^'\">]*\barithmatex\b""",
+    re.IGNORECASE,
+)
+_MATHJAX_SCRIPT = re.compile(
+    r"""<script\b(?=[^>]*\bsrc=(['\"]?)[^'\">]*"""
+    r"""(?:/mathjax\.js|tex-mml-chtml\.js))[^>]*>\s*</script>""",
+    re.IGNORECASE,
+)
+
+
+def on_post_page(output, page, config):
+    if not output or _ARITHMATEX.search(output):
+        return output
+    return _MATHJAX_SCRIPT.sub("", output)

--- a/hooks/stay_on_page.py
+++ b/hooks/stay_on_page.py
@@ -8,8 +8,9 @@ from xml.etree import ElementTree as ET
 # <a hreflang> stays page-relative so Gitee /leetcode/ hosting works.
 # <link rel=alternate> is the current page pair for SEO. Material's
 # setupAlternate then requests sitemap.xml against that href
-# (mkdocs-material#6582, #7352); rewrite_sitemap_pathname maps those
-# requests back to the language-root sitemaps.
+# (mkdocs-material#6582, #7352). Language switching already uses
+# relative <a> tags, so the XHR patch stubs those fetches with an
+# empty urlset instead of downloading the 1.6MB language-root files.
 _HREFLANG_HREF = re.compile(
     r"""
     (?P<prefix>
@@ -30,55 +31,31 @@ _HEAD_END = re.compile(r"</head>", re.IGNORECASE)
 _SITEMAP_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
 _XHTML_NS = "http://www.w3.org/1999/xhtml"
 _CN_ONLY = frozenset(("lcof", "lcof2"))
-_SERIES = frozenset(
-    ("lc", "lcof", "lcof2", "lcci", "lcp", "lcs", "contest", "tags")
+_EMPTY_SITEMAP = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>'
 )
 
-# Keep in sync with rewrite_sitemap_pathname().
+# Material stay-on-page already works via relative <a hreflang>. Stub every
+# sitemap.xml XHR so setupAlternate does not download /sitemap.xml.
 _XHR_PATCH = (
     "<script>"
     "!function(){"
-    "function rewrite(p){"
-    "if(!/sitemap\\.xml$/i.test(p))return p;"
-    "var parts=p.split('/').filter(function(s){return s&&!/^sitemap\\.xml$/i.test(s)});"
-    "var series={lc:1,lcof:1,lcof2:1,lcci:1,lcp:1,lcs:1,contest:1,tags:1};"
-    "var en=-1;"
-    "for(var i=0;i<parts.length;i++)if(parts[i].toLowerCase()==='en'){en=i;break}"
-    "if(en>=0)return'/'+parts.slice(0,en+1).join('/')+'/sitemap.xml';"
-    "if(parts[0]&&series[parts[0]])return'/sitemap.xml';"
-    "if(parts.length>=2&&series[parts[1]])return'/'+parts[0]+'/sitemap.xml';"
-    "if(parts.length===1)return'/'+parts[0]+'/sitemap.xml';"
-    "return'/sitemap.xml'"
-    "}"
+    f"var empty={_EMPTY_SITEMAP!r};"
     "var n=XMLHttpRequest.prototype.open;"
     "XMLHttpRequest.prototype.open=function(m,u){"
     "var a=arguments;"
     "try{"
-    "var x=new URL(String(u),location.href),r=rewrite(x.pathname);"
-    "if(r!==x.pathname){x.pathname=r;a=Array.prototype.slice.call(arguments);a[1]=x.href}"
+    "if(/sitemap\\.xml$/i.test(new URL(String(u),location.href).pathname)){"
+    "a=Array.prototype.slice.call(arguments);"
+    "a[1]='data:application/xml,'+encodeURIComponent(empty)"
+    "}"
     "}catch(e){}"
     "return n.apply(this,a)"
     "}"
     "}()"
     "</script>"
 )
-
-
-def rewrite_sitemap_pathname(pathname: str) -> str:
-    raw = pathname or ""
-    if not raw.lower().endswith("sitemap.xml"):
-        return pathname
-    parts = [p for p in raw.split("/") if p and p.lower() != "sitemap.xml"]
-    en_idx = next((i for i, p in enumerate(parts) if p.lower() == "en"), -1)
-    if en_idx >= 0:
-        return "/" + "/".join(parts[: en_idx + 1]) + "/sitemap.xml"
-    if parts and parts[0] in _SERIES:
-        return "/sitemap.xml"
-    if len(parts) >= 2 and parts[1] in _SERIES:
-        return f"/{parts[0]}/sitemap.xml"
-    if len(parts) == 1:
-        return f"/{parts[0]}/sitemap.xml"
-    return "/sitemap.xml"
 
 
 def _config_get(config, key: str, default=""):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ hooks:
   - hooks/ext_info.py
   - hooks/tags.py
   - hooks/stay_on_page.py
+  - hooks/conditional_mathjax.py
 
 markdown_extensions:
   - admonition

--- a/tests/test_conditional_mathjax.py
+++ b/tests/test_conditional_mathjax.py
@@ -1,0 +1,56 @@
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+import conditional_mathjax as cmj  # noqa: E402
+
+PAGE = SimpleNamespace(url="lc/1/")
+CONFIG = {}
+
+MATHJAX_SCRIPTS = (
+    '<script src="../javascripts/mathjax.js"></script>'
+    '<script src="https://cdn-doocs.oss-cn-shenzhen.aliyuncs.com/npm/mathjax@3/es5/tex-mml-chtml.js"></script>'
+)
+MINIFIED_SCRIPTS = (
+    "<script src=../javascripts/mathjax.js></script>"
+    "<script src=https://cdn-doocs.oss-cn-shenzhen.aliyuncs.com/npm/mathjax@3/es5/tex-mml-chtml.js></script>"
+)
+CONFIG_ONLY = (
+    "<script>window.MathJax={options:{processHtmlClass:'arithmatex'}}</script>"
+    + MATHJAX_SCRIPTS
+)
+
+
+class ConditionalMathjaxTest(unittest.TestCase):
+    def test_keeps_scripts_when_page_has_formula(self):
+        html = f'<p><span class="arithmatex">\\(x\\)</span></p>{MATHJAX_SCRIPTS}'
+        self.assertEqual(cmj.on_post_page(html, PAGE, CONFIG), html)
+
+    def test_strips_scripts_when_page_has_no_formula(self):
+        html = f"<h1>两数之和</h1>{MATHJAX_SCRIPTS}"
+        out = cmj.on_post_page(html, PAGE, CONFIG)
+        self.assertNotIn("mathjax.js", out)
+        self.assertNotIn("tex-mml-chtml.js", out)
+        self.assertIn("两数之和", out)
+
+    def test_strips_minified_scripts(self):
+        html = f"<p>plain</p>{MINIFIED_SCRIPTS}"
+        out = cmj.on_post_page(html, PAGE, CONFIG)
+        self.assertNotIn("mathjax.js", out)
+        self.assertNotIn("tex-mml-chtml.js", out)
+
+    def test_ignores_arithmatex_in_mathjax_config(self):
+        out = cmj.on_post_page(CONFIG_ONLY, PAGE, CONFIG)
+        self.assertNotIn("mathjax.js", out)
+        self.assertNotIn("tex-mml-chtml.js", out)
+        self.assertIn("processHtmlClass", out)
+
+    def test_empty_output(self):
+        self.assertEqual(cmj.on_post_page("", PAGE, CONFIG), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stay_on_page.py
+++ b/tests/test_stay_on_page.py
@@ -122,49 +122,6 @@ class RelativeHrefTest(unittest.TestCase):
         self.assertEqual(sop._relative_href("/", "/en/"), "en/")
 
 
-class RewriteSitemapPathnameTest(unittest.TestCase):
-    def test_language_roots(self):
-        self.assertEqual(sop.rewrite_sitemap_pathname("/sitemap.xml"), "/sitemap.xml")
-        self.assertEqual(sop.rewrite_sitemap_pathname("/en/sitemap.xml"), "/en/sitemap.xml")
-
-    def test_problem_and_range_paths(self):
-        self.assertEqual(sop.rewrite_sitemap_pathname("/lc/100/sitemap.xml"), "/sitemap.xml")
-        self.assertEqual(
-            sop.rewrite_sitemap_pathname("/en/lc/100/sitemap.xml"), "/en/sitemap.xml"
-        )
-        self.assertEqual(
-            sop.rewrite_sitemap_pathname("/lc/0100-0199/sitemap.xml"), "/sitemap.xml"
-        )
-        self.assertEqual(sop.rewrite_sitemap_pathname("/lcof/3/sitemap.xml"), "/sitemap.xml")
-
-    def test_gitee_subdirectory(self):
-        self.assertEqual(
-            sop.rewrite_sitemap_pathname("/leetcode/sitemap.xml"),
-            "/leetcode/sitemap.xml",
-        )
-        self.assertEqual(
-            sop.rewrite_sitemap_pathname("/leetcode/en/sitemap.xml"),
-            "/leetcode/en/sitemap.xml",
-        )
-        self.assertEqual(
-            sop.rewrite_sitemap_pathname("/leetcode/lc/100/sitemap.xml"),
-            "/leetcode/sitemap.xml",
-        )
-        self.assertEqual(
-            sop.rewrite_sitemap_pathname("/leetcode/en/lc/100/sitemap.xml"),
-            "/leetcode/en/sitemap.xml",
-        )
-
-    def test_en_is_a_path_segment(self):
-        self.assertEqual(
-            sop.rewrite_sitemap_pathname("/english/sitemap.xml"),
-            "/english/sitemap.xml",
-        )
-
-    def test_non_sitemap_unchanged(self):
-        self.assertEqual(sop.rewrite_sitemap_pathname("/lc/100/"), "/lc/100/")
-
-
 class StayOnPageTest(unittest.TestCase):
     def _run(self, url: str, config: dict, html: str = HTML) -> str:
         return sop.on_post_page(html, SimpleNamespace(url=url), config)
@@ -182,6 +139,8 @@ class StayOnPageTest(unittest.TestCase):
         )
         self.assertEqual(_sitemap_hrefs(out), ["https://leetcode.doocs.org/sitemap.xml"])
         self.assertIn("XMLHttpRequest.prototype.open", out)
+        self.assertIn("data:application/xml", out)
+        self.assertIn("urlset", out)
         self.assertEqual(_page_sitemaps(out), [])
 
     def test_bilingual_en_page(self):
@@ -233,6 +192,7 @@ class StayOnPageTest(unittest.TestCase):
         self.assertEqual(_hrefs(out, "link")["x-default"], "https://leetcode.doocs.org/lc/100/")
         self.assertEqual(_sitemap_hrefs(out), ["https://leetcode.doocs.org/sitemap.xml"])
         self.assertIn("XMLHttpRequest.prototype.open", out)
+        self.assertIn("data:application/xml", out)
 
     def test_does_not_double_inject_sitemap(self):
         html = HTML.replace(


### PR DESCRIPTION
## Summary
- Strip `mathjax.js` and `tex-mml-chtml.js` on pages that have no `arithmatex` markup, so most problem pages skip the 1.2MB MathJax download.
- Stub Material `setupAlternate` `sitemap.xml` XHRs with an empty urlset. Language switching already uses relative `<a hreflang>` links; this avoids downloading the ~1.6MB language-root sitemaps on every page.
- SEO `<link rel=alternate>` / `<link rel=sitemap>` are unchanged.

## Test plan
- [x] `python -m unittest tests.test_stay_on_page tests.test_conditional_mathjax -v`
- [ ] After deploy, open a page without formulas (e.g. `/lc/1/`): Network should not request `tex-mml-chtml.js` or `/sitemap.xml` / `/en/sitemap.xml`
- [ ] Open a page with formulas: MathJax still typesets
- [ ] Language switcher still stays on the same problem (CN <-> EN)
- [ ] `lcof` / `lcof2` still have no EN `<link rel=alternate>`

Made with [Cursor](https://cursor.com)