### PR TITLE
feat: add a pluggable Ask AI panel for problem pages

### DIFF
--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           python-version: "3.12"
       - name: Run docs hook tests
-        run: python -m unittest tests.test_stay_on_page tests.test_conditional_mathjax -v
+        run: python -m unittest tests.test_stay_on_page tests.test_conditional_mathjax tests.test_ai_assistant -v

--- a/docs-en/javascripts/ai-assistant.js
+++ b/docs-en/javascripts/ai-assistant.js
@@ -1,0 +1,803 @@
+(function () {
+    var SCRIPT = document.getElementById("doocs-ai-config");
+    if (!SCRIPT) {
+        return;
+    }
+
+    var CONFIG;
+    try {
+        CONFIG = JSON.parse(SCRIPT.textContent || "{}");
+    } catch (err) {
+        return;
+    }
+
+    var STORAGE = "doocs-ai.settings";
+    var ZH = CONFIG.lang !== "en";
+    var I18N = ZH
+        ? {
+              title: "问 AI",
+              ask: "问 AI",
+              settings: "设置",
+              close: "关闭",
+              send: "发送",
+              stop: "停止",
+              save: "保存",
+              placeholder: "问这道题，或解释当前代码…",
+              mine: "可选：粘贴你的写法，用来对比",
+              starterExplain: "这题在考什么？",
+              starterWalk: "逐步讲解当前语言题解",
+              starterHint: "先给思路，不要直接贴完整代码",
+              starterCompare: "对比我粘贴的写法",
+              provider: "提供商",
+              model: "模型",
+              key: "API Key（只存在本机浏览器）",
+              base: "接口地址",
+              pluginOn: "浏览器插件已连接",
+              pluginOff: "未检测到插件，直连可能被 CORS 拦截",
+              pluginHelp: "多数模型 API 不允许网页直连。请加载仓库 extensions/doocs-ai 插件，或把接口地址改成你自己的 OpenAI 兼容代理。",
+              needKey: "先在设置里填 API Key",
+              empty: "输入问题，或点上面的快捷提问",
+              error: "请求失败",
+              cors: "浏览器拦截了跨域请求。安装 extensions/doocs-ai 插件，或把接口改成你自己的代理",
+              thinking: "生成中…",
+          }
+        : {
+              title: "Ask AI",
+              ask: "Ask AI",
+              settings: "Settings",
+              close: "Close",
+              send: "Send",
+              stop: "Stop",
+              save: "Save",
+              placeholder: "Ask about this problem or the current solution…",
+              mine: "Optional: paste your code to compare",
+              starterExplain: "What is this problem testing?",
+              starterWalk: "Walk through the current language solution",
+              starterHint: "Give hints first, no full code yet",
+              starterCompare: "Compare with the code I pasted",
+              provider: "Provider",
+              model: "Model",
+              key: "API key (stored only in this browser)",
+              base: "Base URL",
+              pluginOn: "Browser plugin connected",
+              pluginOff: "No plugin detected; direct calls may be blocked by CORS",
+              pluginHelp: "Most model APIs block browser CORS. Load extensions/doocs-ai, or point the base URL at your own OpenAI-compatible proxy.",
+              needKey: "Add an API key in Settings first",
+              empty: "Ask a question, or use a starter prompt",
+              error: "Request failed",
+              cors: "The browser blocked a cross-origin request. Install extensions/doocs-ai, or point the base URL at your proxy",
+              thinking: "Thinking…",
+          };
+
+    var state = {
+        open: false,
+        settings: false,
+        plugin: false,
+        abort: null,
+        messages: [],
+    };
+
+    var els = {};
+
+    function providers() {
+        return CONFIG.providers && CONFIG.providers.length
+            ? CONFIG.providers
+            : [];
+    }
+
+    function loadSettings() {
+        var raw;
+        try {
+            raw = JSON.parse(localStorage.getItem(STORAGE) || "{}");
+        } catch (err) {
+            raw = {};
+        }
+        var list = providers();
+        var first = list[0] || {};
+        var provider = raw.provider || CONFIG.defaultProvider || first.id || "custom";
+        var found = null;
+        for (var i = 0; i < list.length; i++) {
+            if (list[i].id === provider) {
+                found = list[i];
+                break;
+            }
+        }
+        if (!found) {
+            found = first;
+            provider = found.id || "custom";
+        }
+        return {
+            provider: provider,
+            model: raw.model || (found.models && found.models[0]) || "",
+            apiKey: raw.apiKey || "",
+            baseUrl: raw.baseUrl || found.base_url || "",
+        };
+    }
+
+    function saveSettings(next) {
+        localStorage.setItem(STORAGE, JSON.stringify(next));
+    }
+
+    function findProvider(id) {
+        var list = providers();
+        for (var i = 0; i < list.length; i++) {
+            if (list[i].id === id) {
+                return list[i];
+            }
+        }
+        return { id: "custom", name: "Custom", base_url: "", models: [] };
+    }
+
+    function pageTitle() {
+        var h1 = document.querySelector(".md-content h1");
+        return (
+            CONFIG.title ||
+            (h1 && h1.textContent.trim()) ||
+            document.title ||
+            ""
+        );
+    }
+
+    function activeLang() {
+        var inputs = document.querySelectorAll(".tabbed-set > input");
+        for (var i = 0; i < inputs.length; i++) {
+            if (inputs[i].checked) {
+                var label = document.querySelector(
+                    'label[for="' + inputs[i].id + '"]'
+                );
+                return label ? label.textContent.trim() : "";
+            }
+        }
+        return "";
+    }
+
+    function activeCode(limit) {
+        var max = limit || 8000;
+        var sets = document.querySelectorAll(".tabbed-set");
+        for (var s = 0; s < sets.length; s++) {
+            var inputs = sets[s].querySelectorAll(":scope > input");
+            var idx = -1;
+            for (var i = 0; i < inputs.length; i++) {
+                if (inputs[i].checked) {
+                    idx = i;
+                    break;
+                }
+            }
+            var blocks = sets[s].querySelectorAll(
+                ".tabbed-content > .tabbed-block"
+            );
+            var block = idx >= 0 ? blocks[idx] : blocks[0];
+            if (block) {
+                var code = block.querySelector("pre code") || block.querySelector("code");
+                if (code && code.textContent.trim()) {
+                    return code.textContent.trim().slice(0, max);
+                }
+            }
+        }
+        var fallback = document.querySelector(".md-content pre code");
+        return fallback ? fallback.textContent.trim().slice(0, max) : "";
+    }
+
+    function pageExcerpt() {
+        var article = document.querySelector(".md-content__inner");
+        if (!article) {
+            return "";
+        }
+        var clone = article.cloneNode(true);
+        var drop = clone.querySelectorAll(
+            "pre, script, style, .doocs-ai-panel, .md-source-file, .md-feedback"
+        );
+        for (var i = 0; i < drop.length; i++) {
+            drop[i].parentNode.removeChild(drop[i]);
+        }
+        return (clone.textContent || "").replace(/\s+/g, " ").trim().slice(0, 5000);
+    }
+
+    function systemPrompt() {
+        var langLine = ZH
+            ? "用简洁的中文回答。解释本站已经写好的题解，不要另编一套题解，也不要编造不存在的题号。"
+            : "Answer in concise English. Explain the solution already on this page. Do not invent a new solution or problem numbers.";
+        return [
+            "You are the optional AI helper for Doocs LeetCode Wiki.",
+            langLine,
+            "Ground every claim in the provided page context. If something is missing, say so.",
+            "Prefer hints and walkthroughs of the existing code over dumping a replacement.",
+            "When you cite, point at the current page title or a language tab.",
+            "Page title: " + pageTitle(),
+            "Page URL: " + location.href,
+            "Active language tab: " + (activeLang() || "(none)"),
+        ].join("\n");
+    }
+
+    function contextMessage(selection, mine) {
+        var parts = [
+            "Page excerpt:\n" + (pageExcerpt() || "(empty)"),
+            "Current solution (" + (activeLang() || "code") + "):\n" + (activeCode() || "(none)"),
+        ];
+        if (selection) {
+            parts.push("User selection:\n" + selection);
+        }
+        if (mine) {
+            parts.push("User's own code:\n" + mine);
+        }
+        return parts.join("\n\n");
+    }
+
+    function escapeHtml(text) {
+        return String(text)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+    }
+
+    function renderMd(text) {
+        var escaped = escapeHtml(text);
+        escaped = escaped.replace(/```[\w-]*\n([\s\S]*?)```/g, function (_, code) {
+            return '<pre class="doocs-ai-code"><code>' + code + "</code></pre>";
+        });
+        escaped = escaped.replace(/`([^`]+)`/g, "<code>$1</code>");
+        escaped = escaped.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+        escaped = escaped.replace(
+            /\[([^\]]+)\]\((https?:[^)]+)\)/g,
+            '<a href="$2" rel="noopener noreferrer" target="_blank">$1</a>'
+        );
+        return escaped.replace(/\n/g, "<br>");
+    }
+
+    function setStatus() {
+        if (!els.status) {
+            return;
+        }
+        els.status.dataset.ok = state.plugin ? "true" : "false";
+        els.status.textContent = state.plugin ? I18N.pluginOn : I18N.pluginOff;
+    }
+
+    function pingPlugin() {
+        return new Promise(function (resolve) {
+            var done = false;
+            function onMsg(ev) {
+                if (ev.source !== window || !ev.data || ev.data.type !== "doocs-ai-pong") {
+                    return;
+                }
+                done = true;
+                window.removeEventListener("message", onMsg);
+                resolve(true);
+            }
+            window.addEventListener("message", onMsg);
+            window.postMessage({ type: "doocs-ai-ping" }, "*");
+            setTimeout(function () {
+                if (!done) {
+                    window.removeEventListener("message", onMsg);
+                    resolve(false);
+                }
+            }, 250);
+        });
+    }
+
+    function pluginFetch(url, options, onChunk) {
+        return new Promise(function (resolve, reject) {
+            var id = "r" + Date.now() + Math.random().toString(16).slice(2);
+            var body = "";
+            function onMsg(ev) {
+                if (ev.source !== window || !ev.data || ev.data.id !== id) {
+                    return;
+                }
+                var data = ev.data;
+                if (data.type === "doocs-ai-chunk") {
+                    body += data.text || "";
+                    if (onChunk && data.text) {
+                        onChunk(data.text);
+                    }
+                } else if (data.type === "doocs-ai-done") {
+                    window.removeEventListener("message", onMsg);
+                    resolve({ ok: data.ok, status: data.status, body: body });
+                } else if (data.type === "doocs-ai-error") {
+                    window.removeEventListener("message", onMsg);
+                    reject(new Error(data.error || I18N.error));
+                }
+            }
+            window.addEventListener("message", onMsg);
+            window.postMessage(
+                {
+                    type: "doocs-ai-fetch",
+                    id: id,
+                    url: url,
+                    method: options.method || "POST",
+                    headers: options.headers || {},
+                    body: options.body || "",
+                },
+                "*"
+            );
+        });
+    }
+
+    function parseSseDelta(buffer, onDelta) {
+        var parts = buffer.split("\n\n");
+        var rest = parts.pop();
+        for (var i = 0; i < parts.length; i++) {
+            var line = parts[i].replace(/^data:\s*/, "").trim();
+            if (!line || line === "[DONE]") {
+                continue;
+            }
+            try {
+                var json = JSON.parse(line);
+                var delta =
+                    json.choices &&
+                    json.choices[0] &&
+                    json.choices[0].delta &&
+                    json.choices[0].delta.content;
+                if (delta) {
+                    onDelta(delta);
+                }
+            } catch (err) {
+                /* ignore partial JSON */
+            }
+        }
+        return rest;
+    }
+
+    async function directFetch(url, options, onChunk, signal) {
+        var res = await fetch(url, {
+            method: options.method || "POST",
+            headers: options.headers,
+            body: options.body,
+            signal: signal,
+        });
+        if (!res.ok) {
+            var errText = await res.text();
+            throw new Error((errText || res.statusText || I18N.error).slice(0, 400));
+        }
+        if (!res.body || !res.body.getReader) {
+            var full = await res.text();
+            onChunk(full);
+            return;
+        }
+        var reader = res.body.getReader();
+        var decoder = new TextDecoder();
+        var buf = "";
+        while (true) {
+            var step = await reader.read();
+            if (step.done) {
+                break;
+            }
+            buf += decoder.decode(step.value, { stream: true });
+            buf = parseSseDelta(buf, onChunk);
+        }
+        if (buf) {
+            parseSseDelta(buf + "\n\n", onChunk);
+        }
+    }
+
+    async function chat(userText, extras) {
+        var settings = loadSettings();
+        if (!settings.apiKey && settings.provider !== "ollama") {
+            throw new Error(I18N.needKey);
+        }
+        var base = (settings.baseUrl || "").replace(/\/$/, "");
+        if (!base) {
+            throw new Error(I18N.base);
+        }
+        var url = base + "/chat/completions";
+        var payload = {
+            model: settings.model,
+            stream: true,
+            temperature: 0.3,
+            messages: [
+                { role: "system", content: systemPrompt() },
+                { role: "user", content: contextMessage(extras.selection, extras.mine) },
+                { role: "user", content: userText },
+            ],
+        };
+        var headers = { "Content-Type": "application/json" };
+        if (settings.apiKey) {
+            headers.Authorization = "Bearer " + settings.apiKey;
+        }
+        var options = {
+            method: "POST",
+            headers: headers,
+            body: JSON.stringify(payload),
+        };
+        var assembled = "";
+        function onText(chunk) {
+            assembled += chunk;
+            extras.onDelta(assembled);
+        }
+        if (state.plugin) {
+            var sseBuf = "";
+            var result = await pluginFetch(url, options, function (chunk) {
+                sseBuf += chunk;
+                sseBuf = parseSseDelta(sseBuf, function (delta) {
+                    assembled += delta;
+                    extras.onDelta(assembled);
+                });
+            });
+            if (!result.ok) {
+                throw new Error((result.body || I18N.error).slice(0, 400));
+            }
+            if (sseBuf) {
+                parseSseDelta(sseBuf + "\n\n", function (delta) {
+                    assembled += delta;
+                    extras.onDelta(assembled);
+                });
+            }
+            return assembled;
+        }
+        try {
+            await directFetch(url, options, function (delta) {
+                onText(delta);
+            }, extras.signal);
+        } catch (err) {
+            var msg = String((err && err.message) || err);
+            if (/Failed to fetch|NetworkError|CORS/i.test(msg)) {
+                throw new Error(I18N.cors);
+            }
+            throw err;
+        }
+        return assembled;
+    }
+
+    function addMsg(role, html) {
+        var div = document.createElement("div");
+        div.className = "doocs-ai-msg";
+        div.dataset.role = role;
+        div.innerHTML = html;
+        els.body.appendChild(div);
+        els.body.scrollTop = els.body.scrollHeight;
+        return div;
+    }
+
+    function setOpen(open) {
+        state.open = open;
+        els.panel.dataset.open = open ? "true" : "false";
+        els.toggle.dataset.open = open ? "true" : "false";
+        els.panel.setAttribute("aria-hidden", open ? "false" : "true");
+        if (open) {
+            els.input.focus();
+        }
+    }
+
+    function setSettings(open) {
+        state.settings = open;
+        els.settings.dataset.open = open ? "true" : "false";
+        els.body.style.display = open ? "none" : "block";
+        els.foot.style.display = open ? "none" : "flex";
+        if (open) {
+            fillSettings();
+        }
+    }
+
+    function fillSettings() {
+        var settings = loadSettings();
+        var list = providers();
+        els.provider.innerHTML = "";
+        for (var i = 0; i < list.length; i++) {
+            var opt = document.createElement("option");
+            opt.value = list[i].id;
+            opt.textContent = list[i].name;
+            if (list[i].id === settings.provider) {
+                opt.selected = true;
+            }
+            els.provider.appendChild(opt);
+        }
+        fillModels(settings.provider, settings.model);
+        els.apiKey.value = settings.apiKey;
+        els.baseUrl.value = settings.baseUrl;
+    }
+
+    function fillModels(providerId, selected) {
+        var provider = findProvider(providerId);
+        els.model.innerHTML = "";
+        var models = provider.models && provider.models.length ? provider.models : [""];
+        for (var i = 0; i < models.length; i++) {
+            var opt = document.createElement("option");
+            opt.value = models[i];
+            opt.textContent = models[i] || (ZH ? "自定义" : "Custom");
+            if (models[i] === selected) {
+                opt.selected = true;
+            }
+            els.model.appendChild(opt);
+        }
+        if (selected && models.indexOf(selected) < 0) {
+            var extra = document.createElement("option");
+            extra.value = selected;
+            extra.textContent = selected;
+            extra.selected = true;
+            els.model.appendChild(extra);
+        }
+    }
+
+    function persistFromForm() {
+        var provider = findProvider(els.provider.value);
+        saveSettings({
+            provider: els.provider.value,
+            model: els.model.value,
+            apiKey: els.apiKey.value.trim(),
+            baseUrl: els.baseUrl.value.trim() || provider.base_url || "",
+        });
+    }
+
+    async function submit(text, selection) {
+        var query = (text || "").trim();
+        if (!query) {
+            return;
+        }
+        if (state.abort) {
+            state.abort.abort();
+        }
+        setSettings(false);
+        addMsg("user", escapeHtml(query).replace(/\n/g, "<br>"));
+        var bubble = addMsg("assistant", I18N.thinking);
+        var controller = new AbortController();
+        state.abort = controller;
+        els.send.textContent = I18N.stop;
+        try {
+            var answer = await chat(query, {
+                selection: selection || "",
+                mine: (els.mine.value || "").trim(),
+                signal: controller.signal,
+                onDelta: function (full) {
+                    bubble.innerHTML = renderMd(full);
+                    els.body.scrollTop = els.body.scrollHeight;
+                },
+            });
+            bubble.innerHTML = renderMd(answer || I18N.empty);
+        } catch (err) {
+            if (err && err.name === "AbortError") {
+                bubble.innerHTML = renderMd(bubble.textContent || I18N.empty);
+            } else {
+                bubble.textContent = I18N.error + ": " + ((err && err.message) || err);
+            }
+        }
+        state.abort = null;
+        els.send.textContent = I18N.send;
+    }
+
+    function svg(path) {
+        return (
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18">' +
+            '<path fill="currentColor" d="' +
+            path +
+            '"></path></svg>'
+        );
+    }
+
+    function mount() {
+        var toggle = document.createElement("button");
+        toggle.className = "md-header__button md-icon doocs-ai-toggle";
+        toggle.type = "button";
+        toggle.title = I18N.title;
+        toggle.setAttribute("aria-label", I18N.title);
+        toggle.innerHTML = svg(
+            "M12 2l1.4 4.2L18 7.6l-3.3 3 0.8 4.4L12 13.2 8.5 15l0.8-4.4L6 7.6l4.6-1.4L12 2m0 8.2l1.2 2.4 2.6.4-1.9 1.8.4 2.6L12 13.8 9.7 15.4l.4-2.6-1.9-1.8 2.6-.4L12 10.2z"
+        );
+
+        var header = document.querySelector(".md-header__inner");
+        if (header) {
+            header.appendChild(toggle);
+        } else {
+            document.body.appendChild(toggle);
+        }
+
+        var panel = document.createElement("aside");
+        panel.className = "doocs-ai-panel";
+        panel.dataset.open = "false";
+        panel.setAttribute("aria-hidden", "true");
+        panel.innerHTML =
+            '<div class="doocs-ai-head">' +
+            "<h2>" +
+            I18N.title +
+            "</h2>" +
+            '<button type="button" class="doocs-ai-icon" data-act="settings" title="' +
+            I18N.settings +
+            '">' +
+            svg("M12 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8m8.9 4a7.9 7.9 0 0 0-.2-1.6l2.1-1.6-2-3.4-2.5 1a8 8 0 0 0-2.8-1.6L15 2h-6l-.5 2.8a8 8 0 0 0-2.8 1.6l-2.5-1-2 3.4 2.1 1.6A8 8 0 0 0 3.1 12c0 .5.1 1.1.2 1.6L1.2 15.2l2 3.4 2.5-1a8 8 0 0 0 2.8 1.6L9 22h6l.5-2.8a8 8 0 0 0 2.8-1.6l2.5 1 2-3.4-2.1-1.6c.1-.5.2-1.1.2-1.6z") +
+            "</button>" +
+            '<button type="button" class="doocs-ai-icon" data-act="close" title="' +
+            I18N.close +
+            '">' +
+            svg("M19 6.4L17.6 5 12 10.6 6.4 5 5 6.4 10.6 12 5 17.6 6.4 19 12 13.4 17.6 19 19 17.6 13.4 12 19 6.4z") +
+            "</button>" +
+            "</div>" +
+            '<div class="doocs-ai-status"></div>' +
+            '<div class="doocs-ai-body"></div>' +
+            '<div class="doocs-ai-settings">' +
+            "<label>" +
+            I18N.provider +
+            '</label><select data-field="provider"></select>' +
+            "<label>" +
+            I18N.model +
+            '</label><select data-field="model"></select>' +
+            "<label>" +
+            I18N.base +
+            '</label><input data-field="base" spellcheck="false">' +
+            "<label>" +
+            I18N.key +
+            '</label><input data-field="key" type="password" autocomplete="off" spellcheck="false">' +
+            '<button type="button" class="doocs-ai-save" data-act="save">' +
+            I18N.save +
+            "</button>" +
+            '<p class="doocs-ai-help">' +
+            I18N.pluginHelp +
+            "</p>" +
+            "</div>" +
+            '<div class="doocs-ai-foot">' +
+            '<div class="doocs-ai-starters">' +
+            '<button type="button" data-q="explain">' +
+            I18N.starterExplain +
+            "</button>" +
+            '<button type="button" data-q="walk">' +
+            I18N.starterWalk +
+            "</button>" +
+            '<button type="button" data-q="hint">' +
+            I18N.starterHint +
+            "</button>" +
+            '<button type="button" data-q="compare">' +
+            I18N.starterCompare +
+            "</button>" +
+            "</div>" +
+            '<textarea class="doocs-ai-mine" placeholder="' +
+            I18N.mine +
+            '"></textarea>' +
+            '<div class="doocs-ai-composer">' +
+            '<textarea data-field="input" placeholder="' +
+            I18N.placeholder +
+            '"></textarea>' +
+            '<button type="button" class="doocs-ai-send" data-act="send">' +
+            I18N.send +
+            "</button>" +
+            "</div></div>";
+
+        document.body.appendChild(panel);
+
+        var ask = document.createElement("button");
+        ask.type = "button";
+        ask.className = "doocs-ai-ask";
+        ask.textContent = I18N.ask;
+        document.body.appendChild(ask);
+
+        els.toggle = toggle;
+        els.panel = panel;
+        els.status = panel.querySelector(".doocs-ai-status");
+        els.body = panel.querySelector(".doocs-ai-body");
+        els.settings = panel.querySelector(".doocs-ai-settings");
+        els.foot = panel.querySelector(".doocs-ai-foot");
+        els.provider = panel.querySelector('[data-field="provider"]');
+        els.model = panel.querySelector('[data-field="model"]');
+        els.baseUrl = panel.querySelector('[data-field="base"]');
+        els.apiKey = panel.querySelector('[data-field="key"]');
+        els.input = panel.querySelector('[data-field="input"]');
+        els.mine = panel.querySelector(".doocs-ai-mine");
+        els.send = panel.querySelector('[data-act="send"]');
+        els.ask = ask;
+
+        addMsg("assistant", I18N.empty);
+        setStatus();
+
+        toggle.addEventListener("click", function () {
+            setOpen(!state.open);
+        });
+        panel.querySelector('[data-act="close"]').addEventListener("click", function () {
+            setOpen(false);
+        });
+        panel.querySelector('[data-act="settings"]').addEventListener("click", function () {
+            setSettings(!state.settings);
+        });
+        panel.querySelector('[data-act="save"]').addEventListener("click", function () {
+            persistFromForm();
+            setSettings(false);
+        });
+        els.provider.addEventListener("change", function () {
+            var provider = findProvider(els.provider.value);
+            els.baseUrl.value = provider.base_url || "";
+            fillModels(provider.id, provider.models && provider.models[0]);
+        });
+        els.send.addEventListener("click", function () {
+            if (state.abort) {
+                state.abort.abort();
+                return;
+            }
+            submit(els.input.value);
+            els.input.value = "";
+        });
+        els.input.addEventListener("keydown", function (ev) {
+            if (ev.key === "Enter" && !ev.shiftKey) {
+                ev.preventDefault();
+                submit(els.input.value);
+                els.input.value = "";
+            }
+        });
+        panel.querySelectorAll("[data-q]").forEach(function (btn) {
+            btn.addEventListener("click", function () {
+                var map = {
+                    explain: I18N.starterExplain,
+                    walk: I18N.starterWalk,
+                    hint: I18N.starterHint,
+                    compare: I18N.starterCompare,
+                };
+                submit(map[btn.getAttribute("data-q")] || btn.textContent);
+            });
+        });
+        ask.addEventListener("click", function () {
+            var selected = (window.getSelection() && window.getSelection().toString()) || "";
+            ask.style.display = "none";
+            setOpen(true);
+            submit(I18N.starterExplain, selected);
+        });
+
+        document.addEventListener("keydown", function (ev) {
+            if ((ev.ctrlKey || ev.metaKey) && ev.key.toLowerCase() === "i") {
+                ev.preventDefault();
+                setOpen(!state.open);
+            }
+            if (ev.key === "Escape" && state.open) {
+                setOpen(false);
+            }
+        });
+        document.addEventListener("mouseup", function () {
+            var sel = window.getSelection();
+            var text = sel && String(sel).trim();
+            if (!text || text.length < 2) {
+                ask.style.display = "none";
+                return;
+            }
+            try {
+                var rect = sel.getRangeAt(0).getBoundingClientRect();
+                ask.style.display = "block";
+                ask.style.top = window.scrollY + rect.bottom + 8 + "px";
+                ask.style.left = window.scrollX + rect.left + "px";
+            } catch (err) {
+                ask.style.display = "none";
+            }
+        });
+
+        bindCodeButtons();
+        if (window.document$ && document$.subscribe) {
+            document$.subscribe(function () {
+                bindCodeButtons();
+            });
+        }
+    }
+
+    function bindCodeButtons() {
+        var blocks = document.querySelectorAll(".md-content .highlight, .md-content pre");
+        for (var i = 0; i < blocks.length; i++) {
+            var host = blocks[i];
+            if (host.tagName === "PRE" && host.closest(".highlight")) {
+                continue;
+            }
+            if (host.querySelector(".doocs-ai-codebtn")) {
+                continue;
+            }
+            var btn = document.createElement("button");
+            btn.type = "button";
+            btn.className = "doocs-ai-codebtn";
+            btn.textContent = I18N.ask;
+            btn.addEventListener("click", function (ev) {
+                ev.preventDefault();
+                var host = ev.currentTarget.parentNode;
+                var code = host.querySelector("code");
+                setOpen(true);
+                submit(I18N.starterWalk, code ? code.textContent.trim().slice(0, 8000) : "");
+            });
+            host.insertBefore(btn, host.firstChild);
+        }
+    }
+
+    async function boot() {
+        mount();
+        state.plugin = await pingPlugin();
+        setStatus();
+        if (els.settings) {
+            var help = els.settings.querySelector(".doocs-ai-help");
+            if (help) {
+                help.textContent = state.plugin ? I18N.pluginOn : I18N.pluginHelp;
+            }
+        }
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", boot);
+    } else {
+        boot();
+    }
+})();

--- a/docs-en/javascripts/ai-assistant.js
+++ b/docs-en/javascripts/ai-assistant.js
@@ -35,6 +35,10 @@
               pluginOn: "浏览器插件已连接",
               pluginOff: "未检测到插件，直连可能被 CORS 拦截",
               pluginHelp: "多数模型 API 不允许网页直连。请加载仓库 extensions/doocs-ai 插件，或把接口地址改成你自己的 OpenAI 兼容代理。",
+              hosted: "站点内置服务，无需配置",
+              hostedHelp: "默认走站点代理，不用填 Key。只有要换自己的模型时，才打开「使用自己的 Key」。",
+              hostedDown: "内置服务未启动。部署 workers/ai-proxy，或在设置里改用自己的 Key",
+              useOwn: "使用自己的 API Key",
               needKey: "先在设置里填 API Key",
               empty: "输入问题，或点上面的快捷提问",
               error: "请求失败",
@@ -62,6 +66,10 @@
               pluginOn: "Browser plugin connected",
               pluginOff: "No plugin detected; direct calls may be blocked by CORS",
               pluginHelp: "Most model APIs block browser CORS. Load extensions/doocs-ai, or point the base URL at your own OpenAI-compatible proxy.",
+              hosted: "Built-in service, no setup needed",
+              hostedHelp: "Requests go through the site proxy. Enable “Use my API key” only if you want your own model.",
+              hostedDown: "Built-in service is offline. Deploy workers/ai-proxy, or use your own key in Settings",
+              useOwn: "Use my API key",
               needKey: "Add an API key in Settings first",
               empty: "Ask a question, or use a starter prompt",
               error: "Request failed",
@@ -111,7 +119,23 @@
             model: raw.model || (found.models && found.models[0]) || "",
             apiKey: raw.apiKey || "",
             baseUrl: raw.baseUrl || found.base_url || "",
+            useOwnKey: !!raw.useOwnKey,
         };
+    }
+
+    function hostedEndpoint() {
+        if (CONFIG.endpoint) {
+            return CONFIG.endpoint;
+        }
+        var host = location.hostname;
+        if (host === "127.0.0.1" || host === "localhost") {
+            return "http://127.0.0.1:8787/chat";
+        }
+        return "";
+    }
+
+    function useHosted() {
+        return hostedEndpoint() && !loadSettings().useOwnKey;
     }
 
     function saveSettings(next) {
@@ -248,6 +272,11 @@
         if (!els.status) {
             return;
         }
+        if (useHosted()) {
+            els.status.dataset.ok = "true";
+            els.status.textContent = I18N.hosted;
+            return;
+        }
         els.status.dataset.ok = state.plugin ? "true" : "false";
         els.status.textContent = state.plugin ? I18N.pluginOn : I18N.pluginOff;
     }
@@ -368,7 +397,48 @@
         }
     }
 
+    async function hostedChat(userText, extras) {
+        var url = hostedEndpoint();
+        var options = {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                lang: ZH ? "zh" : "en",
+                title: pageTitle(),
+                url: location.href,
+                langTab: activeLang(),
+                excerpt: pageExcerpt(),
+                code: activeCode(),
+                selection: extras.selection || "",
+                mine: extras.mine || "",
+                query: userText,
+            }),
+        };
+        var assembled = "";
+        try {
+            await directFetch(
+                url,
+                options,
+                function (delta) {
+                    assembled += delta;
+                    extras.onDelta(assembled);
+                },
+                extras.signal
+            );
+        } catch (err) {
+            var msg = String((err && err.message) || err);
+            if (/Failed to fetch|NetworkError|CORS/i.test(msg)) {
+                throw new Error(I18N.hostedDown);
+            }
+            throw err;
+        }
+        return assembled;
+    }
+
     async function chat(userText, extras) {
+        if (useHosted()) {
+            return hostedChat(userText, extras);
+        }
         var settings = loadSettings();
         if (!settings.apiKey && settings.provider !== "ollama") {
             throw new Error(I18N.needKey);
@@ -482,6 +552,9 @@
         fillModels(settings.provider, settings.model);
         els.apiKey.value = settings.apiKey;
         els.baseUrl.value = settings.baseUrl;
+        if (els.useOwn) {
+            els.useOwn.checked = !!settings.useOwnKey;
+        }
     }
 
     function fillModels(providerId, selected) {
@@ -513,7 +586,9 @@
             model: els.model.value,
             apiKey: els.apiKey.value.trim(),
             baseUrl: els.baseUrl.value.trim() || provider.base_url || "",
+            useOwnKey: !!(els.useOwn && els.useOwn.checked),
         });
+        setStatus();
     }
 
     async function submit(text, selection) {
@@ -601,6 +676,9 @@
             '<div class="doocs-ai-status"></div>' +
             '<div class="doocs-ai-body"></div>' +
             '<div class="doocs-ai-settings">' +
+            "<label><input type=\"checkbox\" data-field=\"own\"> " +
+            I18N.useOwn +
+            "</label>" +
             "<label>" +
             I18N.provider +
             '</label><select data-field="provider"></select>' +
@@ -665,6 +743,7 @@
         els.model = panel.querySelector('[data-field="model"]');
         els.baseUrl = panel.querySelector('[data-field="base"]');
         els.apiKey = panel.querySelector('[data-field="key"]');
+        els.useOwn = panel.querySelector('[data-field="own"]');
         els.input = panel.querySelector('[data-field="input"]');
         els.mine = panel.querySelector(".doocs-ai-mine");
         els.send = panel.querySelector('[data-act="send"]');
@@ -790,7 +869,11 @@
         if (els.settings) {
             var help = els.settings.querySelector(".doocs-ai-help");
             if (help) {
-                help.textContent = state.plugin ? I18N.pluginOn : I18N.pluginHelp;
+                help.textContent = useHosted()
+                    ? I18N.hostedHelp
+                    : state.plugin
+                      ? I18N.pluginOn
+                      : I18N.pluginHelp;
             }
         }
     }

--- a/docs-en/stylesheets/ai-assistant.css
+++ b/docs-en/stylesheets/ai-assistant.css
@@ -179,6 +179,10 @@
     color: var(--md-default-fg-color--light);
 }
 
+.doocs-ai-settings label:has(input[type="checkbox"]) {
+    color: var(--md-default-fg-color);
+}
+
 .doocs-ai-settings .doocs-ai-help {
     margin: 0.7rem 0 0;
     color: var(--md-default-fg-color--light);

--- a/docs-en/stylesheets/ai-assistant.css
+++ b/docs-en/stylesheets/ai-assistant.css
@@ -1,0 +1,219 @@
+.doocs-ai-toggle {
+    margin-left: 0.2rem;
+}
+
+.doocs-ai-toggle[data-open="true"] {
+    color: var(--md-accent-fg-color);
+}
+
+.doocs-ai-panel {
+    position: fixed;
+    top: 0;
+    right: 0;
+    z-index: 12;
+    display: flex;
+    flex-direction: column;
+    width: min(26rem, 100vw);
+    height: 100%;
+    background: var(--md-default-bg-color);
+    color: var(--md-default-fg-color);
+    box-shadow: 0 0 1.2rem rgba(0, 0, 0, 0.18);
+    transform: translateX(100%);
+    transition: transform 0.2s ease;
+}
+
+.doocs-ai-panel[data-open="true"] {
+    transform: translateX(0);
+}
+
+.doocs-ai-head,
+.doocs-ai-foot {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.7rem 0.8rem;
+    border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.doocs-ai-foot {
+    border-bottom: 0;
+    border-top: 1px solid var(--md-default-fg-color--lightest);
+    flex-direction: column;
+    align-items: stretch;
+}
+
+.doocs-ai-head h2 {
+    flex: 1;
+    margin: 0;
+    font-size: 0.85rem;
+    font-weight: 700;
+}
+
+.doocs-ai-icon {
+    width: 1.2rem;
+    height: 1.2rem;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--md-default-fg-color);
+    cursor: pointer;
+}
+
+.doocs-ai-icon:hover {
+    color: var(--md-accent-fg-color);
+}
+
+.doocs-ai-status {
+    padding: 0.35rem 0.8rem;
+    font-size: 0.65rem;
+    color: var(--md-default-fg-color--light);
+    background: var(--md-code-bg-color, var(--md-default-fg-color--lightest));
+}
+
+.doocs-ai-status[data-ok="true"] {
+    color: var(--md-accent-fg-color);
+}
+
+.doocs-ai-body {
+    flex: 1;
+    overflow: auto;
+    padding: 0.8rem;
+}
+
+.doocs-ai-msg {
+    margin: 0 0 0.8rem;
+    padding: 0.65rem 0.75rem;
+    border-radius: 0.4rem;
+    font-size: 0.72rem;
+    line-height: 1.55;
+    overflow-wrap: anywhere;
+}
+
+.doocs-ai-msg[data-role="user"] {
+    margin-left: 1.5rem;
+    background: var(--md-code-bg-color, var(--md-default-fg-color--lightest));
+}
+
+.doocs-ai-msg[data-role="assistant"] {
+    margin-right: 1.5rem;
+    background: var(--md-primary-fg-color--light, var(--md-default-fg-color--lightest));
+}
+
+.doocs-ai-msg pre {
+    margin: 0.4rem 0 0;
+    padding: 0.5rem;
+    overflow: auto;
+    font-size: 0.68rem;
+}
+
+.doocs-ai-starters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-bottom: 0.6rem;
+}
+
+.doocs-ai-starters button,
+.doocs-ai-send,
+.doocs-ai-save {
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--md-default-fg-color);
+    font-size: 0.65rem;
+    padding: 0.25rem 0.65rem;
+    cursor: pointer;
+}
+
+.doocs-ai-starters button:hover,
+.doocs-ai-send:hover,
+.doocs-ai-save:hover {
+    border-color: var(--md-accent-fg-color);
+    color: var(--md-accent-fg-color);
+}
+
+.doocs-ai-composer {
+    display: flex;
+    gap: 0.4rem;
+}
+
+.doocs-ai-composer textarea,
+.doocs-ai-mine,
+.doocs-ai-settings input,
+.doocs-ai-settings select {
+    width: 100%;
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-radius: 0.3rem;
+    background: var(--md-default-bg-color);
+    color: var(--md-default-fg-color);
+    font: inherit;
+    font-size: 0.7rem;
+    padding: 0.45rem 0.55rem;
+}
+
+.doocs-ai-composer textarea {
+    min-height: 3.4rem;
+    resize: vertical;
+}
+
+.doocs-ai-send {
+    align-self: flex-end;
+    border-radius: 0.3rem;
+    padding: 0.45rem 0.7rem;
+}
+
+.doocs-ai-settings {
+    display: none;
+    padding: 0.8rem;
+    overflow: auto;
+    font-size: 0.7rem;
+}
+
+.doocs-ai-settings[data-open="true"] {
+    display: block;
+}
+
+.doocs-ai-settings label {
+    display: block;
+    margin: 0.55rem 0 0.2rem;
+    color: var(--md-default-fg-color--light);
+}
+
+.doocs-ai-settings .doocs-ai-help {
+    margin: 0.7rem 0 0;
+    color: var(--md-default-fg-color--light);
+    font-size: 0.65rem;
+    line-height: 1.5;
+}
+
+.doocs-ai-ask {
+    position: absolute;
+    z-index: 13;
+    display: none;
+    border: 0;
+    border-radius: 999px;
+    padding: 0.2rem 0.55rem;
+    background: var(--md-primary-fg-color);
+    color: var(--md-primary-bg-color, #fff);
+    font-size: 0.65rem;
+    cursor: pointer;
+}
+
+.doocs-ai-codebtn {
+    margin-left: 0.25rem;
+    border: 0;
+    background: transparent;
+    color: var(--md-default-fg-color--light);
+    font-size: 0.6rem;
+    cursor: pointer;
+}
+
+.doocs-ai-codebtn:hover {
+    color: var(--md-accent-fg-color);
+}
+
+@media screen and (max-width: 76.1875em) {
+    .doocs-ai-panel {
+        width: 100vw;
+    }
+}

--- a/docs/javascripts/ai-assistant.js
+++ b/docs/javascripts/ai-assistant.js
@@ -1,0 +1,803 @@
+(function () {
+    var SCRIPT = document.getElementById("doocs-ai-config");
+    if (!SCRIPT) {
+        return;
+    }
+
+    var CONFIG;
+    try {
+        CONFIG = JSON.parse(SCRIPT.textContent || "{}");
+    } catch (err) {
+        return;
+    }
+
+    var STORAGE = "doocs-ai.settings";
+    var ZH = CONFIG.lang !== "en";
+    var I18N = ZH
+        ? {
+              title: "问 AI",
+              ask: "问 AI",
+              settings: "设置",
+              close: "关闭",
+              send: "发送",
+              stop: "停止",
+              save: "保存",
+              placeholder: "问这道题，或解释当前代码…",
+              mine: "可选：粘贴你的写法，用来对比",
+              starterExplain: "这题在考什么？",
+              starterWalk: "逐步讲解当前语言题解",
+              starterHint: "先给思路，不要直接贴完整代码",
+              starterCompare: "对比我粘贴的写法",
+              provider: "提供商",
+              model: "模型",
+              key: "API Key（只存在本机浏览器）",
+              base: "接口地址",
+              pluginOn: "浏览器插件已连接",
+              pluginOff: "未检测到插件，直连可能被 CORS 拦截",
+              pluginHelp: "多数模型 API 不允许网页直连。请加载仓库 extensions/doocs-ai 插件，或把接口地址改成你自己的 OpenAI 兼容代理。",
+              needKey: "先在设置里填 API Key",
+              empty: "输入问题，或点上面的快捷提问",
+              error: "请求失败",
+              cors: "浏览器拦截了跨域请求。安装 extensions/doocs-ai 插件，或把接口改成你自己的代理",
+              thinking: "生成中…",
+          }
+        : {
+              title: "Ask AI",
+              ask: "Ask AI",
+              settings: "Settings",
+              close: "Close",
+              send: "Send",
+              stop: "Stop",
+              save: "Save",
+              placeholder: "Ask about this problem or the current solution…",
+              mine: "Optional: paste your code to compare",
+              starterExplain: "What is this problem testing?",
+              starterWalk: "Walk through the current language solution",
+              starterHint: "Give hints first, no full code yet",
+              starterCompare: "Compare with the code I pasted",
+              provider: "Provider",
+              model: "Model",
+              key: "API key (stored only in this browser)",
+              base: "Base URL",
+              pluginOn: "Browser plugin connected",
+              pluginOff: "No plugin detected; direct calls may be blocked by CORS",
+              pluginHelp: "Most model APIs block browser CORS. Load extensions/doocs-ai, or point the base URL at your own OpenAI-compatible proxy.",
+              needKey: "Add an API key in Settings first",
+              empty: "Ask a question, or use a starter prompt",
+              error: "Request failed",
+              cors: "The browser blocked a cross-origin request. Install extensions/doocs-ai, or point the base URL at your proxy",
+              thinking: "Thinking…",
+          };
+
+    var state = {
+        open: false,
+        settings: false,
+        plugin: false,
+        abort: null,
+        messages: [],
+    };
+
+    var els = {};
+
+    function providers() {
+        return CONFIG.providers && CONFIG.providers.length
+            ? CONFIG.providers
+            : [];
+    }
+
+    function loadSettings() {
+        var raw;
+        try {
+            raw = JSON.parse(localStorage.getItem(STORAGE) || "{}");
+        } catch (err) {
+            raw = {};
+        }
+        var list = providers();
+        var first = list[0] || {};
+        var provider = raw.provider || CONFIG.defaultProvider || first.id || "custom";
+        var found = null;
+        for (var i = 0; i < list.length; i++) {
+            if (list[i].id === provider) {
+                found = list[i];
+                break;
+            }
+        }
+        if (!found) {
+            found = first;
+            provider = found.id || "custom";
+        }
+        return {
+            provider: provider,
+            model: raw.model || (found.models && found.models[0]) || "",
+            apiKey: raw.apiKey || "",
+            baseUrl: raw.baseUrl || found.base_url || "",
+        };
+    }
+
+    function saveSettings(next) {
+        localStorage.setItem(STORAGE, JSON.stringify(next));
+    }
+
+    function findProvider(id) {
+        var list = providers();
+        for (var i = 0; i < list.length; i++) {
+            if (list[i].id === id) {
+                return list[i];
+            }
+        }
+        return { id: "custom", name: "Custom", base_url: "", models: [] };
+    }
+
+    function pageTitle() {
+        var h1 = document.querySelector(".md-content h1");
+        return (
+            CONFIG.title ||
+            (h1 && h1.textContent.trim()) ||
+            document.title ||
+            ""
+        );
+    }
+
+    function activeLang() {
+        var inputs = document.querySelectorAll(".tabbed-set > input");
+        for (var i = 0; i < inputs.length; i++) {
+            if (inputs[i].checked) {
+                var label = document.querySelector(
+                    'label[for="' + inputs[i].id + '"]'
+                );
+                return label ? label.textContent.trim() : "";
+            }
+        }
+        return "";
+    }
+
+    function activeCode(limit) {
+        var max = limit || 8000;
+        var sets = document.querySelectorAll(".tabbed-set");
+        for (var s = 0; s < sets.length; s++) {
+            var inputs = sets[s].querySelectorAll(":scope > input");
+            var idx = -1;
+            for (var i = 0; i < inputs.length; i++) {
+                if (inputs[i].checked) {
+                    idx = i;
+                    break;
+                }
+            }
+            var blocks = sets[s].querySelectorAll(
+                ".tabbed-content > .tabbed-block"
+            );
+            var block = idx >= 0 ? blocks[idx] : blocks[0];
+            if (block) {
+                var code = block.querySelector("pre code") || block.querySelector("code");
+                if (code && code.textContent.trim()) {
+                    return code.textContent.trim().slice(0, max);
+                }
+            }
+        }
+        var fallback = document.querySelector(".md-content pre code");
+        return fallback ? fallback.textContent.trim().slice(0, max) : "";
+    }
+
+    function pageExcerpt() {
+        var article = document.querySelector(".md-content__inner");
+        if (!article) {
+            return "";
+        }
+        var clone = article.cloneNode(true);
+        var drop = clone.querySelectorAll(
+            "pre, script, style, .doocs-ai-panel, .md-source-file, .md-feedback"
+        );
+        for (var i = 0; i < drop.length; i++) {
+            drop[i].parentNode.removeChild(drop[i]);
+        }
+        return (clone.textContent || "").replace(/\s+/g, " ").trim().slice(0, 5000);
+    }
+
+    function systemPrompt() {
+        var langLine = ZH
+            ? "用简洁的中文回答。解释本站已经写好的题解，不要另编一套题解，也不要编造不存在的题号。"
+            : "Answer in concise English. Explain the solution already on this page. Do not invent a new solution or problem numbers.";
+        return [
+            "You are the optional AI helper for Doocs LeetCode Wiki.",
+            langLine,
+            "Ground every claim in the provided page context. If something is missing, say so.",
+            "Prefer hints and walkthroughs of the existing code over dumping a replacement.",
+            "When you cite, point at the current page title or a language tab.",
+            "Page title: " + pageTitle(),
+            "Page URL: " + location.href,
+            "Active language tab: " + (activeLang() || "(none)"),
+        ].join("\n");
+    }
+
+    function contextMessage(selection, mine) {
+        var parts = [
+            "Page excerpt:\n" + (pageExcerpt() || "(empty)"),
+            "Current solution (" + (activeLang() || "code") + "):\n" + (activeCode() || "(none)"),
+        ];
+        if (selection) {
+            parts.push("User selection:\n" + selection);
+        }
+        if (mine) {
+            parts.push("User's own code:\n" + mine);
+        }
+        return parts.join("\n\n");
+    }
+
+    function escapeHtml(text) {
+        return String(text)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+    }
+
+    function renderMd(text) {
+        var escaped = escapeHtml(text);
+        escaped = escaped.replace(/```[\w-]*\n([\s\S]*?)```/g, function (_, code) {
+            return '<pre class="doocs-ai-code"><code>' + code + "</code></pre>";
+        });
+        escaped = escaped.replace(/`([^`]+)`/g, "<code>$1</code>");
+        escaped = escaped.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+        escaped = escaped.replace(
+            /\[([^\]]+)\]\((https?:[^)]+)\)/g,
+            '<a href="$2" rel="noopener noreferrer" target="_blank">$1</a>'
+        );
+        return escaped.replace(/\n/g, "<br>");
+    }
+
+    function setStatus() {
+        if (!els.status) {
+            return;
+        }
+        els.status.dataset.ok = state.plugin ? "true" : "false";
+        els.status.textContent = state.plugin ? I18N.pluginOn : I18N.pluginOff;
+    }
+
+    function pingPlugin() {
+        return new Promise(function (resolve) {
+            var done = false;
+            function onMsg(ev) {
+                if (ev.source !== window || !ev.data || ev.data.type !== "doocs-ai-pong") {
+                    return;
+                }
+                done = true;
+                window.removeEventListener("message", onMsg);
+                resolve(true);
+            }
+            window.addEventListener("message", onMsg);
+            window.postMessage({ type: "doocs-ai-ping" }, "*");
+            setTimeout(function () {
+                if (!done) {
+                    window.removeEventListener("message", onMsg);
+                    resolve(false);
+                }
+            }, 250);
+        });
+    }
+
+    function pluginFetch(url, options, onChunk) {
+        return new Promise(function (resolve, reject) {
+            var id = "r" + Date.now() + Math.random().toString(16).slice(2);
+            var body = "";
+            function onMsg(ev) {
+                if (ev.source !== window || !ev.data || ev.data.id !== id) {
+                    return;
+                }
+                var data = ev.data;
+                if (data.type === "doocs-ai-chunk") {
+                    body += data.text || "";
+                    if (onChunk && data.text) {
+                        onChunk(data.text);
+                    }
+                } else if (data.type === "doocs-ai-done") {
+                    window.removeEventListener("message", onMsg);
+                    resolve({ ok: data.ok, status: data.status, body: body });
+                } else if (data.type === "doocs-ai-error") {
+                    window.removeEventListener("message", onMsg);
+                    reject(new Error(data.error || I18N.error));
+                }
+            }
+            window.addEventListener("message", onMsg);
+            window.postMessage(
+                {
+                    type: "doocs-ai-fetch",
+                    id: id,
+                    url: url,
+                    method: options.method || "POST",
+                    headers: options.headers || {},
+                    body: options.body || "",
+                },
+                "*"
+            );
+        });
+    }
+
+    function parseSseDelta(buffer, onDelta) {
+        var parts = buffer.split("\n\n");
+        var rest = parts.pop();
+        for (var i = 0; i < parts.length; i++) {
+            var line = parts[i].replace(/^data:\s*/, "").trim();
+            if (!line || line === "[DONE]") {
+                continue;
+            }
+            try {
+                var json = JSON.parse(line);
+                var delta =
+                    json.choices &&
+                    json.choices[0] &&
+                    json.choices[0].delta &&
+                    json.choices[0].delta.content;
+                if (delta) {
+                    onDelta(delta);
+                }
+            } catch (err) {
+                /* ignore partial JSON */
+            }
+        }
+        return rest;
+    }
+
+    async function directFetch(url, options, onChunk, signal) {
+        var res = await fetch(url, {
+            method: options.method || "POST",
+            headers: options.headers,
+            body: options.body,
+            signal: signal,
+        });
+        if (!res.ok) {
+            var errText = await res.text();
+            throw new Error((errText || res.statusText || I18N.error).slice(0, 400));
+        }
+        if (!res.body || !res.body.getReader) {
+            var full = await res.text();
+            onChunk(full);
+            return;
+        }
+        var reader = res.body.getReader();
+        var decoder = new TextDecoder();
+        var buf = "";
+        while (true) {
+            var step = await reader.read();
+            if (step.done) {
+                break;
+            }
+            buf += decoder.decode(step.value, { stream: true });
+            buf = parseSseDelta(buf, onChunk);
+        }
+        if (buf) {
+            parseSseDelta(buf + "\n\n", onChunk);
+        }
+    }
+
+    async function chat(userText, extras) {
+        var settings = loadSettings();
+        if (!settings.apiKey && settings.provider !== "ollama") {
+            throw new Error(I18N.needKey);
+        }
+        var base = (settings.baseUrl || "").replace(/\/$/, "");
+        if (!base) {
+            throw new Error(I18N.base);
+        }
+        var url = base + "/chat/completions";
+        var payload = {
+            model: settings.model,
+            stream: true,
+            temperature: 0.3,
+            messages: [
+                { role: "system", content: systemPrompt() },
+                { role: "user", content: contextMessage(extras.selection, extras.mine) },
+                { role: "user", content: userText },
+            ],
+        };
+        var headers = { "Content-Type": "application/json" };
+        if (settings.apiKey) {
+            headers.Authorization = "Bearer " + settings.apiKey;
+        }
+        var options = {
+            method: "POST",
+            headers: headers,
+            body: JSON.stringify(payload),
+        };
+        var assembled = "";
+        function onText(chunk) {
+            assembled += chunk;
+            extras.onDelta(assembled);
+        }
+        if (state.plugin) {
+            var sseBuf = "";
+            var result = await pluginFetch(url, options, function (chunk) {
+                sseBuf += chunk;
+                sseBuf = parseSseDelta(sseBuf, function (delta) {
+                    assembled += delta;
+                    extras.onDelta(assembled);
+                });
+            });
+            if (!result.ok) {
+                throw new Error((result.body || I18N.error).slice(0, 400));
+            }
+            if (sseBuf) {
+                parseSseDelta(sseBuf + "\n\n", function (delta) {
+                    assembled += delta;
+                    extras.onDelta(assembled);
+                });
+            }
+            return assembled;
+        }
+        try {
+            await directFetch(url, options, function (delta) {
+                onText(delta);
+            }, extras.signal);
+        } catch (err) {
+            var msg = String((err && err.message) || err);
+            if (/Failed to fetch|NetworkError|CORS/i.test(msg)) {
+                throw new Error(I18N.cors);
+            }
+            throw err;
+        }
+        return assembled;
+    }
+
+    function addMsg(role, html) {
+        var div = document.createElement("div");
+        div.className = "doocs-ai-msg";
+        div.dataset.role = role;
+        div.innerHTML = html;
+        els.body.appendChild(div);
+        els.body.scrollTop = els.body.scrollHeight;
+        return div;
+    }
+
+    function setOpen(open) {
+        state.open = open;
+        els.panel.dataset.open = open ? "true" : "false";
+        els.toggle.dataset.open = open ? "true" : "false";
+        els.panel.setAttribute("aria-hidden", open ? "false" : "true");
+        if (open) {
+            els.input.focus();
+        }
+    }
+
+    function setSettings(open) {
+        state.settings = open;
+        els.settings.dataset.open = open ? "true" : "false";
+        els.body.style.display = open ? "none" : "block";
+        els.foot.style.display = open ? "none" : "flex";
+        if (open) {
+            fillSettings();
+        }
+    }
+
+    function fillSettings() {
+        var settings = loadSettings();
+        var list = providers();
+        els.provider.innerHTML = "";
+        for (var i = 0; i < list.length; i++) {
+            var opt = document.createElement("option");
+            opt.value = list[i].id;
+            opt.textContent = list[i].name;
+            if (list[i].id === settings.provider) {
+                opt.selected = true;
+            }
+            els.provider.appendChild(opt);
+        }
+        fillModels(settings.provider, settings.model);
+        els.apiKey.value = settings.apiKey;
+        els.baseUrl.value = settings.baseUrl;
+    }
+
+    function fillModels(providerId, selected) {
+        var provider = findProvider(providerId);
+        els.model.innerHTML = "";
+        var models = provider.models && provider.models.length ? provider.models : [""];
+        for (var i = 0; i < models.length; i++) {
+            var opt = document.createElement("option");
+            opt.value = models[i];
+            opt.textContent = models[i] || (ZH ? "自定义" : "Custom");
+            if (models[i] === selected) {
+                opt.selected = true;
+            }
+            els.model.appendChild(opt);
+        }
+        if (selected && models.indexOf(selected) < 0) {
+            var extra = document.createElement("option");
+            extra.value = selected;
+            extra.textContent = selected;
+            extra.selected = true;
+            els.model.appendChild(extra);
+        }
+    }
+
+    function persistFromForm() {
+        var provider = findProvider(els.provider.value);
+        saveSettings({
+            provider: els.provider.value,
+            model: els.model.value,
+            apiKey: els.apiKey.value.trim(),
+            baseUrl: els.baseUrl.value.trim() || provider.base_url || "",
+        });
+    }
+
+    async function submit(text, selection) {
+        var query = (text || "").trim();
+        if (!query) {
+            return;
+        }
+        if (state.abort) {
+            state.abort.abort();
+        }
+        setSettings(false);
+        addMsg("user", escapeHtml(query).replace(/\n/g, "<br>"));
+        var bubble = addMsg("assistant", I18N.thinking);
+        var controller = new AbortController();
+        state.abort = controller;
+        els.send.textContent = I18N.stop;
+        try {
+            var answer = await chat(query, {
+                selection: selection || "",
+                mine: (els.mine.value || "").trim(),
+                signal: controller.signal,
+                onDelta: function (full) {
+                    bubble.innerHTML = renderMd(full);
+                    els.body.scrollTop = els.body.scrollHeight;
+                },
+            });
+            bubble.innerHTML = renderMd(answer || I18N.empty);
+        } catch (err) {
+            if (err && err.name === "AbortError") {
+                bubble.innerHTML = renderMd(bubble.textContent || I18N.empty);
+            } else {
+                bubble.textContent = I18N.error + ": " + ((err && err.message) || err);
+            }
+        }
+        state.abort = null;
+        els.send.textContent = I18N.send;
+    }
+
+    function svg(path) {
+        return (
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18">' +
+            '<path fill="currentColor" d="' +
+            path +
+            '"></path></svg>'
+        );
+    }
+
+    function mount() {
+        var toggle = document.createElement("button");
+        toggle.className = "md-header__button md-icon doocs-ai-toggle";
+        toggle.type = "button";
+        toggle.title = I18N.title;
+        toggle.setAttribute("aria-label", I18N.title);
+        toggle.innerHTML = svg(
+            "M12 2l1.4 4.2L18 7.6l-3.3 3 0.8 4.4L12 13.2 8.5 15l0.8-4.4L6 7.6l4.6-1.4L12 2m0 8.2l1.2 2.4 2.6.4-1.9 1.8.4 2.6L12 13.8 9.7 15.4l.4-2.6-1.9-1.8 2.6-.4L12 10.2z"
+        );
+
+        var header = document.querySelector(".md-header__inner");
+        if (header) {
+            header.appendChild(toggle);
+        } else {
+            document.body.appendChild(toggle);
+        }
+
+        var panel = document.createElement("aside");
+        panel.className = "doocs-ai-panel";
+        panel.dataset.open = "false";
+        panel.setAttribute("aria-hidden", "true");
+        panel.innerHTML =
+            '<div class="doocs-ai-head">' +
+            "<h2>" +
+            I18N.title +
+            "</h2>" +
+            '<button type="button" class="doocs-ai-icon" data-act="settings" title="' +
+            I18N.settings +
+            '">' +
+            svg("M12 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8m8.9 4a7.9 7.9 0 0 0-.2-1.6l2.1-1.6-2-3.4-2.5 1a8 8 0 0 0-2.8-1.6L15 2h-6l-.5 2.8a8 8 0 0 0-2.8 1.6l-2.5-1-2 3.4 2.1 1.6A8 8 0 0 0 3.1 12c0 .5.1 1.1.2 1.6L1.2 15.2l2 3.4 2.5-1a8 8 0 0 0 2.8 1.6L9 22h6l.5-2.8a8 8 0 0 0 2.8-1.6l2.5 1 2-3.4-2.1-1.6c.1-.5.2-1.1.2-1.6z") +
+            "</button>" +
+            '<button type="button" class="doocs-ai-icon" data-act="close" title="' +
+            I18N.close +
+            '">' +
+            svg("M19 6.4L17.6 5 12 10.6 6.4 5 5 6.4 10.6 12 5 17.6 6.4 19 12 13.4 17.6 19 19 17.6 13.4 12 19 6.4z") +
+            "</button>" +
+            "</div>" +
+            '<div class="doocs-ai-status"></div>' +
+            '<div class="doocs-ai-body"></div>' +
+            '<div class="doocs-ai-settings">' +
+            "<label>" +
+            I18N.provider +
+            '</label><select data-field="provider"></select>' +
+            "<label>" +
+            I18N.model +
+            '</label><select data-field="model"></select>' +
+            "<label>" +
+            I18N.base +
+            '</label><input data-field="base" spellcheck="false">' +
+            "<label>" +
+            I18N.key +
+            '</label><input data-field="key" type="password" autocomplete="off" spellcheck="false">' +
+            '<button type="button" class="doocs-ai-save" data-act="save">' +
+            I18N.save +
+            "</button>" +
+            '<p class="doocs-ai-help">' +
+            I18N.pluginHelp +
+            "</p>" +
+            "</div>" +
+            '<div class="doocs-ai-foot">' +
+            '<div class="doocs-ai-starters">' +
+            '<button type="button" data-q="explain">' +
+            I18N.starterExplain +
+            "</button>" +
+            '<button type="button" data-q="walk">' +
+            I18N.starterWalk +
+            "</button>" +
+            '<button type="button" data-q="hint">' +
+            I18N.starterHint +
+            "</button>" +
+            '<button type="button" data-q="compare">' +
+            I18N.starterCompare +
+            "</button>" +
+            "</div>" +
+            '<textarea class="doocs-ai-mine" placeholder="' +
+            I18N.mine +
+            '"></textarea>' +
+            '<div class="doocs-ai-composer">' +
+            '<textarea data-field="input" placeholder="' +
+            I18N.placeholder +
+            '"></textarea>' +
+            '<button type="button" class="doocs-ai-send" data-act="send">' +
+            I18N.send +
+            "</button>" +
+            "</div></div>";
+
+        document.body.appendChild(panel);
+
+        var ask = document.createElement("button");
+        ask.type = "button";
+        ask.className = "doocs-ai-ask";
+        ask.textContent = I18N.ask;
+        document.body.appendChild(ask);
+
+        els.toggle = toggle;
+        els.panel = panel;
+        els.status = panel.querySelector(".doocs-ai-status");
+        els.body = panel.querySelector(".doocs-ai-body");
+        els.settings = panel.querySelector(".doocs-ai-settings");
+        els.foot = panel.querySelector(".doocs-ai-foot");
+        els.provider = panel.querySelector('[data-field="provider"]');
+        els.model = panel.querySelector('[data-field="model"]');
+        els.baseUrl = panel.querySelector('[data-field="base"]');
+        els.apiKey = panel.querySelector('[data-field="key"]');
+        els.input = panel.querySelector('[data-field="input"]');
+        els.mine = panel.querySelector(".doocs-ai-mine");
+        els.send = panel.querySelector('[data-act="send"]');
+        els.ask = ask;
+
+        addMsg("assistant", I18N.empty);
+        setStatus();
+
+        toggle.addEventListener("click", function () {
+            setOpen(!state.open);
+        });
+        panel.querySelector('[data-act="close"]').addEventListener("click", function () {
+            setOpen(false);
+        });
+        panel.querySelector('[data-act="settings"]').addEventListener("click", function () {
+            setSettings(!state.settings);
+        });
+        panel.querySelector('[data-act="save"]').addEventListener("click", function () {
+            persistFromForm();
+            setSettings(false);
+        });
+        els.provider.addEventListener("change", function () {
+            var provider = findProvider(els.provider.value);
+            els.baseUrl.value = provider.base_url || "";
+            fillModels(provider.id, provider.models && provider.models[0]);
+        });
+        els.send.addEventListener("click", function () {
+            if (state.abort) {
+                state.abort.abort();
+                return;
+            }
+            submit(els.input.value);
+            els.input.value = "";
+        });
+        els.input.addEventListener("keydown", function (ev) {
+            if (ev.key === "Enter" && !ev.shiftKey) {
+                ev.preventDefault();
+                submit(els.input.value);
+                els.input.value = "";
+            }
+        });
+        panel.querySelectorAll("[data-q]").forEach(function (btn) {
+            btn.addEventListener("click", function () {
+                var map = {
+                    explain: I18N.starterExplain,
+                    walk: I18N.starterWalk,
+                    hint: I18N.starterHint,
+                    compare: I18N.starterCompare,
+                };
+                submit(map[btn.getAttribute("data-q")] || btn.textContent);
+            });
+        });
+        ask.addEventListener("click", function () {
+            var selected = (window.getSelection() && window.getSelection().toString()) || "";
+            ask.style.display = "none";
+            setOpen(true);
+            submit(I18N.starterExplain, selected);
+        });
+
+        document.addEventListener("keydown", function (ev) {
+            if ((ev.ctrlKey || ev.metaKey) && ev.key.toLowerCase() === "i") {
+                ev.preventDefault();
+                setOpen(!state.open);
+            }
+            if (ev.key === "Escape" && state.open) {
+                setOpen(false);
+            }
+        });
+        document.addEventListener("mouseup", function () {
+            var sel = window.getSelection();
+            var text = sel && String(sel).trim();
+            if (!text || text.length < 2) {
+                ask.style.display = "none";
+                return;
+            }
+            try {
+                var rect = sel.getRangeAt(0).getBoundingClientRect();
+                ask.style.display = "block";
+                ask.style.top = window.scrollY + rect.bottom + 8 + "px";
+                ask.style.left = window.scrollX + rect.left + "px";
+            } catch (err) {
+                ask.style.display = "none";
+            }
+        });
+
+        bindCodeButtons();
+        if (window.document$ && document$.subscribe) {
+            document$.subscribe(function () {
+                bindCodeButtons();
+            });
+        }
+    }
+
+    function bindCodeButtons() {
+        var blocks = document.querySelectorAll(".md-content .highlight, .md-content pre");
+        for (var i = 0; i < blocks.length; i++) {
+            var host = blocks[i];
+            if (host.tagName === "PRE" && host.closest(".highlight")) {
+                continue;
+            }
+            if (host.querySelector(".doocs-ai-codebtn")) {
+                continue;
+            }
+            var btn = document.createElement("button");
+            btn.type = "button";
+            btn.className = "doocs-ai-codebtn";
+            btn.textContent = I18N.ask;
+            btn.addEventListener("click", function (ev) {
+                ev.preventDefault();
+                var host = ev.currentTarget.parentNode;
+                var code = host.querySelector("code");
+                setOpen(true);
+                submit(I18N.starterWalk, code ? code.textContent.trim().slice(0, 8000) : "");
+            });
+            host.insertBefore(btn, host.firstChild);
+        }
+    }
+
+    async function boot() {
+        mount();
+        state.plugin = await pingPlugin();
+        setStatus();
+        if (els.settings) {
+            var help = els.settings.querySelector(".doocs-ai-help");
+            if (help) {
+                help.textContent = state.plugin ? I18N.pluginOn : I18N.pluginHelp;
+            }
+        }
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", boot);
+    } else {
+        boot();
+    }
+})();

--- a/docs/javascripts/ai-assistant.js
+++ b/docs/javascripts/ai-assistant.js
@@ -35,6 +35,10 @@
               pluginOn: "浏览器插件已连接",
               pluginOff: "未检测到插件，直连可能被 CORS 拦截",
               pluginHelp: "多数模型 API 不允许网页直连。请加载仓库 extensions/doocs-ai 插件，或把接口地址改成你自己的 OpenAI 兼容代理。",
+              hosted: "站点内置服务，无需配置",
+              hostedHelp: "默认走站点代理，不用填 Key。只有要换自己的模型时，才打开「使用自己的 Key」。",
+              hostedDown: "内置服务未启动。部署 workers/ai-proxy，或在设置里改用自己的 Key",
+              useOwn: "使用自己的 API Key",
               needKey: "先在设置里填 API Key",
               empty: "输入问题，或点上面的快捷提问",
               error: "请求失败",
@@ -62,6 +66,10 @@
               pluginOn: "Browser plugin connected",
               pluginOff: "No plugin detected; direct calls may be blocked by CORS",
               pluginHelp: "Most model APIs block browser CORS. Load extensions/doocs-ai, or point the base URL at your own OpenAI-compatible proxy.",
+              hosted: "Built-in service, no setup needed",
+              hostedHelp: "Requests go through the site proxy. Enable “Use my API key” only if you want your own model.",
+              hostedDown: "Built-in service is offline. Deploy workers/ai-proxy, or use your own key in Settings",
+              useOwn: "Use my API key",
               needKey: "Add an API key in Settings first",
               empty: "Ask a question, or use a starter prompt",
               error: "Request failed",
@@ -111,7 +119,23 @@
             model: raw.model || (found.models && found.models[0]) || "",
             apiKey: raw.apiKey || "",
             baseUrl: raw.baseUrl || found.base_url || "",
+            useOwnKey: !!raw.useOwnKey,
         };
+    }
+
+    function hostedEndpoint() {
+        if (CONFIG.endpoint) {
+            return CONFIG.endpoint;
+        }
+        var host = location.hostname;
+        if (host === "127.0.0.1" || host === "localhost") {
+            return "http://127.0.0.1:8787/chat";
+        }
+        return "";
+    }
+
+    function useHosted() {
+        return hostedEndpoint() && !loadSettings().useOwnKey;
     }
 
     function saveSettings(next) {
@@ -248,6 +272,11 @@
         if (!els.status) {
             return;
         }
+        if (useHosted()) {
+            els.status.dataset.ok = "true";
+            els.status.textContent = I18N.hosted;
+            return;
+        }
         els.status.dataset.ok = state.plugin ? "true" : "false";
         els.status.textContent = state.plugin ? I18N.pluginOn : I18N.pluginOff;
     }
@@ -368,7 +397,48 @@
         }
     }
 
+    async function hostedChat(userText, extras) {
+        var url = hostedEndpoint();
+        var options = {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                lang: ZH ? "zh" : "en",
+                title: pageTitle(),
+                url: location.href,
+                langTab: activeLang(),
+                excerpt: pageExcerpt(),
+                code: activeCode(),
+                selection: extras.selection || "",
+                mine: extras.mine || "",
+                query: userText,
+            }),
+        };
+        var assembled = "";
+        try {
+            await directFetch(
+                url,
+                options,
+                function (delta) {
+                    assembled += delta;
+                    extras.onDelta(assembled);
+                },
+                extras.signal
+            );
+        } catch (err) {
+            var msg = String((err && err.message) || err);
+            if (/Failed to fetch|NetworkError|CORS/i.test(msg)) {
+                throw new Error(I18N.hostedDown);
+            }
+            throw err;
+        }
+        return assembled;
+    }
+
     async function chat(userText, extras) {
+        if (useHosted()) {
+            return hostedChat(userText, extras);
+        }
         var settings = loadSettings();
         if (!settings.apiKey && settings.provider !== "ollama") {
             throw new Error(I18N.needKey);
@@ -482,6 +552,9 @@
         fillModels(settings.provider, settings.model);
         els.apiKey.value = settings.apiKey;
         els.baseUrl.value = settings.baseUrl;
+        if (els.useOwn) {
+            els.useOwn.checked = !!settings.useOwnKey;
+        }
     }
 
     function fillModels(providerId, selected) {
@@ -513,7 +586,9 @@
             model: els.model.value,
             apiKey: els.apiKey.value.trim(),
             baseUrl: els.baseUrl.value.trim() || provider.base_url || "",
+            useOwnKey: !!(els.useOwn && els.useOwn.checked),
         });
+        setStatus();
     }
 
     async function submit(text, selection) {
@@ -601,6 +676,9 @@
             '<div class="doocs-ai-status"></div>' +
             '<div class="doocs-ai-body"></div>' +
             '<div class="doocs-ai-settings">' +
+            "<label><input type=\"checkbox\" data-field=\"own\"> " +
+            I18N.useOwn +
+            "</label>" +
             "<label>" +
             I18N.provider +
             '</label><select data-field="provider"></select>' +
@@ -665,6 +743,7 @@
         els.model = panel.querySelector('[data-field="model"]');
         els.baseUrl = panel.querySelector('[data-field="base"]');
         els.apiKey = panel.querySelector('[data-field="key"]');
+        els.useOwn = panel.querySelector('[data-field="own"]');
         els.input = panel.querySelector('[data-field="input"]');
         els.mine = panel.querySelector(".doocs-ai-mine");
         els.send = panel.querySelector('[data-act="send"]');
@@ -790,7 +869,11 @@
         if (els.settings) {
             var help = els.settings.querySelector(".doocs-ai-help");
             if (help) {
-                help.textContent = state.plugin ? I18N.pluginOn : I18N.pluginHelp;
+                help.textContent = useHosted()
+                    ? I18N.hostedHelp
+                    : state.plugin
+                      ? I18N.pluginOn
+                      : I18N.pluginHelp;
             }
         }
     }

--- a/docs/stylesheets/ai-assistant.css
+++ b/docs/stylesheets/ai-assistant.css
@@ -179,6 +179,10 @@
     color: var(--md-default-fg-color--light);
 }
 
+.doocs-ai-settings label:has(input[type="checkbox"]) {
+    color: var(--md-default-fg-color);
+}
+
 .doocs-ai-settings .doocs-ai-help {
     margin: 0.7rem 0 0;
     color: var(--md-default-fg-color--light);

--- a/docs/stylesheets/ai-assistant.css
+++ b/docs/stylesheets/ai-assistant.css
@@ -1,0 +1,219 @@
+.doocs-ai-toggle {
+    margin-left: 0.2rem;
+}
+
+.doocs-ai-toggle[data-open="true"] {
+    color: var(--md-accent-fg-color);
+}
+
+.doocs-ai-panel {
+    position: fixed;
+    top: 0;
+    right: 0;
+    z-index: 12;
+    display: flex;
+    flex-direction: column;
+    width: min(26rem, 100vw);
+    height: 100%;
+    background: var(--md-default-bg-color);
+    color: var(--md-default-fg-color);
+    box-shadow: 0 0 1.2rem rgba(0, 0, 0, 0.18);
+    transform: translateX(100%);
+    transition: transform 0.2s ease;
+}
+
+.doocs-ai-panel[data-open="true"] {
+    transform: translateX(0);
+}
+
+.doocs-ai-head,
+.doocs-ai-foot {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.7rem 0.8rem;
+    border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.doocs-ai-foot {
+    border-bottom: 0;
+    border-top: 1px solid var(--md-default-fg-color--lightest);
+    flex-direction: column;
+    align-items: stretch;
+}
+
+.doocs-ai-head h2 {
+    flex: 1;
+    margin: 0;
+    font-size: 0.85rem;
+    font-weight: 700;
+}
+
+.doocs-ai-icon {
+    width: 1.2rem;
+    height: 1.2rem;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--md-default-fg-color);
+    cursor: pointer;
+}
+
+.doocs-ai-icon:hover {
+    color: var(--md-accent-fg-color);
+}
+
+.doocs-ai-status {
+    padding: 0.35rem 0.8rem;
+    font-size: 0.65rem;
+    color: var(--md-default-fg-color--light);
+    background: var(--md-code-bg-color, var(--md-default-fg-color--lightest));
+}
+
+.doocs-ai-status[data-ok="true"] {
+    color: var(--md-accent-fg-color);
+}
+
+.doocs-ai-body {
+    flex: 1;
+    overflow: auto;
+    padding: 0.8rem;
+}
+
+.doocs-ai-msg {
+    margin: 0 0 0.8rem;
+    padding: 0.65rem 0.75rem;
+    border-radius: 0.4rem;
+    font-size: 0.72rem;
+    line-height: 1.55;
+    overflow-wrap: anywhere;
+}
+
+.doocs-ai-msg[data-role="user"] {
+    margin-left: 1.5rem;
+    background: var(--md-code-bg-color, var(--md-default-fg-color--lightest));
+}
+
+.doocs-ai-msg[data-role="assistant"] {
+    margin-right: 1.5rem;
+    background: var(--md-primary-fg-color--light, var(--md-default-fg-color--lightest));
+}
+
+.doocs-ai-msg pre {
+    margin: 0.4rem 0 0;
+    padding: 0.5rem;
+    overflow: auto;
+    font-size: 0.68rem;
+}
+
+.doocs-ai-starters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-bottom: 0.6rem;
+}
+
+.doocs-ai-starters button,
+.doocs-ai-send,
+.doocs-ai-save {
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--md-default-fg-color);
+    font-size: 0.65rem;
+    padding: 0.25rem 0.65rem;
+    cursor: pointer;
+}
+
+.doocs-ai-starters button:hover,
+.doocs-ai-send:hover,
+.doocs-ai-save:hover {
+    border-color: var(--md-accent-fg-color);
+    color: var(--md-accent-fg-color);
+}
+
+.doocs-ai-composer {
+    display: flex;
+    gap: 0.4rem;
+}
+
+.doocs-ai-composer textarea,
+.doocs-ai-mine,
+.doocs-ai-settings input,
+.doocs-ai-settings select {
+    width: 100%;
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-radius: 0.3rem;
+    background: var(--md-default-bg-color);
+    color: var(--md-default-fg-color);
+    font: inherit;
+    font-size: 0.7rem;
+    padding: 0.45rem 0.55rem;
+}
+
+.doocs-ai-composer textarea {
+    min-height: 3.4rem;
+    resize: vertical;
+}
+
+.doocs-ai-send {
+    align-self: flex-end;
+    border-radius: 0.3rem;
+    padding: 0.45rem 0.7rem;
+}
+
+.doocs-ai-settings {
+    display: none;
+    padding: 0.8rem;
+    overflow: auto;
+    font-size: 0.7rem;
+}
+
+.doocs-ai-settings[data-open="true"] {
+    display: block;
+}
+
+.doocs-ai-settings label {
+    display: block;
+    margin: 0.55rem 0 0.2rem;
+    color: var(--md-default-fg-color--light);
+}
+
+.doocs-ai-settings .doocs-ai-help {
+    margin: 0.7rem 0 0;
+    color: var(--md-default-fg-color--light);
+    font-size: 0.65rem;
+    line-height: 1.5;
+}
+
+.doocs-ai-ask {
+    position: absolute;
+    z-index: 13;
+    display: none;
+    border: 0;
+    border-radius: 999px;
+    padding: 0.2rem 0.55rem;
+    background: var(--md-primary-fg-color);
+    color: var(--md-primary-bg-color, #fff);
+    font-size: 0.65rem;
+    cursor: pointer;
+}
+
+.doocs-ai-codebtn {
+    margin-left: 0.25rem;
+    border: 0;
+    background: transparent;
+    color: var(--md-default-fg-color--light);
+    font-size: 0.6rem;
+    cursor: pointer;
+}
+
+.doocs-ai-codebtn:hover {
+    color: var(--md-accent-fg-color);
+}
+
+@media screen and (max-width: 76.1875em) {
+    .doocs-ai-panel {
+        width: 100vw;
+    }
+}

--- a/extensions/doocs-ai/README.md
+++ b/extensions/doocs-ai/README.md
@@ -1,0 +1,9 @@
+# Doocs LeetCode AI plugin
+
+Optional Chromium extension that lets the wiki Ask AI panel call OpenAI-compatible APIs without CORS.
+
+1. Open `chrome://extensions` (or Edge `edge://extensions`).
+2. Enable Developer mode.
+3. Load unpacked and select this folder.
+4. Reload [leetcode.doocs.org](https://leetcode.doocs.org). The panel status should say the plugin is connected.
+5. In the panel settings, pick a provider and paste your own API key. The key stays in `localStorage` on the wiki origin; the extension only forwards the HTTPS request.

--- a/extensions/doocs-ai/background.js
+++ b/extensions/doocs-ai/background.js
@@ -1,0 +1,41 @@
+chrome.runtime.onConnect.addListener((port) => {
+  if (port.name !== "doocs-ai") {
+    return;
+  }
+  port.onMessage.addListener(async (msg) => {
+    if (!msg || msg.type !== "fetch") {
+      return;
+    }
+    try {
+      const res = await fetch(msg.url, {
+        method: msg.method || "POST",
+        headers: msg.headers || {},
+        body: msg.body || undefined,
+      });
+      port.postMessage({ type: "meta", ok: res.ok, status: res.status });
+      if (!res.body || !res.body.getReader) {
+        port.postMessage({ type: "chunk", text: await res.text() });
+        port.postMessage({ type: "done" });
+        return;
+      }
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      while (true) {
+        const step = await reader.read();
+        if (step.done) {
+          break;
+        }
+        port.postMessage({
+          type: "chunk",
+          text: decoder.decode(step.value, { stream: true }),
+        });
+      }
+      port.postMessage({ type: "done" });
+    } catch (err) {
+      port.postMessage({
+        type: "error",
+        error: String((err && err.message) || err),
+      });
+    }
+  });
+});

--- a/extensions/doocs-ai/content.js
+++ b/extensions/doocs-ai/content.js
@@ -1,0 +1,55 @@
+window.addEventListener("message", (event) => {
+  if (event.source !== window || !event.data) {
+    return;
+  }
+  if (event.data.type === "doocs-ai-ping") {
+    window.postMessage({ type: "doocs-ai-pong", version: 1 }, "*");
+    return;
+  }
+  if (event.data.type !== "doocs-ai-fetch") {
+    return;
+  }
+
+  const id = event.data.id;
+  const port = chrome.runtime.connect({ name: "doocs-ai" });
+  let ok = false;
+  let status = 0;
+
+  port.onMessage.addListener((msg) => {
+    if (msg.type === "meta") {
+      ok = msg.ok;
+      status = msg.status;
+      return;
+    }
+    if (msg.type === "chunk") {
+      window.postMessage(
+        { type: "doocs-ai-chunk", id: id, text: msg.text || "" },
+        "*"
+      );
+      return;
+    }
+    if (msg.type === "done") {
+      window.postMessage(
+        { type: "doocs-ai-done", id: id, ok: ok, status: status },
+        "*"
+      );
+      port.disconnect();
+      return;
+    }
+    if (msg.type === "error") {
+      window.postMessage(
+        { type: "doocs-ai-error", id: id, error: msg.error },
+        "*"
+      );
+      port.disconnect();
+    }
+  });
+
+  port.postMessage({
+    type: "fetch",
+    url: event.data.url,
+    method: event.data.method,
+    headers: event.data.headers,
+    body: event.data.body,
+  });
+});

--- a/extensions/doocs-ai/manifest.json
+++ b/extensions/doocs-ai/manifest.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 3,
+  "name": "Doocs LeetCode AI",
+  "version": "1.0.0",
+  "description": "Optional transport plugin for leetcode.doocs.org Ask AI. Forwards OpenAI-compatible chat requests and avoids browser CORS.",
+  "permissions": [],
+  "host_permissions": [
+    "https://*/*",
+    "http://127.0.0.1:*/*",
+    "http://localhost:*/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://leetcode.doocs.org/*",
+        "https://doocs.gitee.io/*",
+        "http://127.0.0.1/*",
+        "http://localhost/*"
+      ],
+      "js": ["content.js"],
+      "run_at": "document_start"
+    }
+  ]
+}

--- a/hooks/ai_assistant.py
+++ b/hooks/ai_assistant.py
@@ -1,0 +1,120 @@
+import json
+import re
+
+# Injects a page-scoped config blob. The widget itself is a static
+# extra_javascript / extra_css pair so it can be turned off without
+# deleting files: set extra.ai.enabled to false.
+
+_HEAD_END = re.compile(r"</head>", re.IGNORECASE)
+_AI_ASSET = re.compile(
+    r"""<(?:script|link)\b[^>]*(?:/ai-assistant\.js|ai-assistant\.css)[^>]*>"""
+    r"""(?:\s*</script>)?""",
+    re.IGNORECASE,
+)
+
+DEFAULT_PROVIDERS = (
+    {
+        "id": "deepseek",
+        "name": "DeepSeek",
+        "base_url": "https://api.deepseek.com/v1",
+        "models": ["deepseek-chat", "deepseek-reasoner"],
+    },
+    {
+        "id": "qwen",
+        "name": "Qwen",
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "models": ["qwen-plus", "qwen-turbo"],
+    },
+    {
+        "id": "siliconflow",
+        "name": "SiliconFlow",
+        "base_url": "https://api.siliconflow.cn/v1",
+        "models": ["deepseek-ai/DeepSeek-V3.2", "Qwen/Qwen3-8B"],
+    },
+    {
+        "id": "openai",
+        "name": "OpenAI",
+        "base_url": "https://api.openai.com/v1",
+        "models": ["gpt-4.1-mini", "gpt-4o-mini"],
+    },
+    {
+        "id": "ollama",
+        "name": "Ollama",
+        "base_url": "http://127.0.0.1:11434/v1",
+        "models": ["llama3.2", "qwen2.5"],
+    },
+    {
+        "id": "custom",
+        "name": "Custom",
+        "base_url": "",
+        "models": [],
+    },
+)
+
+
+def _config_get(config, key, default=None):
+    if isinstance(config, dict):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _extra(config) -> dict:
+    extra = _config_get(config, "extra") or {}
+    return extra if isinstance(extra, dict) else {}
+
+
+def is_enabled(config) -> bool:
+    ai = _extra(config).get("ai")
+    if ai is None:
+        return True
+    if isinstance(ai, dict):
+        return bool(ai.get("enabled", True))
+    return bool(ai)
+
+
+def is_en_site(config) -> bool:
+    site_url = str(_config_get(config, "site_url") or "").rstrip("/")
+    site_dir = str(_config_get(config, "site_dir") or "").replace("\\", "/").rstrip("/")
+    return site_url.endswith("/en") or site_dir.endswith("/en") or site_dir == "en"
+
+
+def build_config(page, config) -> dict:
+    ai = _extra(config).get("ai")
+    ai = ai if isinstance(ai, dict) else {}
+    providers = ai.get("providers") or DEFAULT_PROVIDERS
+    title = getattr(page, "title", None) or ""
+    url = (getattr(page, "url", None) or "").strip()
+    return {
+        "lang": "en" if is_en_site(config) else "zh",
+        "title": title,
+        "url": url,
+        "defaultProvider": ai.get("default_provider") or "deepseek",
+        "providers": providers,
+        "plugin": True,
+    }
+
+
+def _config_script(payload: dict) -> str:
+    body = (
+        json.dumps(payload, ensure_ascii=False)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+    )
+    return (
+        '<script type="application/json" id="doocs-ai-config">'
+        f"{body}"
+        "</script>"
+    )
+
+
+def on_post_page(output, page, config):
+    if not output:
+        return output
+    if not is_enabled(config):
+        return _AI_ASSET.sub("", output)
+    if 'id="doocs-ai-config"' in output or "id=doocs-ai-config" in output:
+        return output
+    snippet = _config_script(build_config(page, config))
+    if _HEAD_END.search(output):
+        return _HEAD_END.sub(f"{snippet}</head>", output, count=1)
+    return snippet + output

--- a/hooks/ai_assistant.py
+++ b/hooks/ai_assistant.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 
 # Injects a page-scoped config blob. The widget itself is a static
@@ -84,10 +85,12 @@ def build_config(page, config) -> dict:
     providers = ai.get("providers") or DEFAULT_PROVIDERS
     title = getattr(page, "title", None) or ""
     url = (getattr(page, "url", None) or "").strip()
+    endpoint = str(ai.get("endpoint") or os.environ.get("DOOCS_AI_ENDPOINT") or "").strip()
     return {
         "lang": "en" if is_en_site(config) else "zh",
         "title": title,
         "url": url,
+        "endpoint": endpoint,
         "defaultProvider": ai.get("default_provider") or "deepseek",
         "providers": providers,
         "plugin": True,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ hooks:
   - hooks/tags.py
   - hooks/stay_on_page.py
   - hooks/conditional_mathjax.py
+  - hooks/ai_assistant.py
 
 markdown_extensions:
   - admonition
@@ -126,11 +127,16 @@ markdown_extensions:
 extra_javascript:
   - javascripts/mathjax.js
   - https://cdn-doocs.oss-cn-shenzhen.aliyuncs.com/npm/mathjax@3/es5/tex-mml-chtml.js
+  - javascripts/ai-assistant.js
 
 extra_css:
   - stylesheets/extra.css
+  - stylesheets/ai-assistant.css
 
 extra:
+  ai:
+    enabled: true
+    default_provider: deepseek
   generator: false
   social:
     - icon: fontawesome/brands/github

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,8 @@ extra_css:
 extra:
   ai:
     enabled: true
+    # After deploying workers/ai-proxy, set this to the Worker /chat URL.
+    endpoint: ""
     default_provider: deepseek
   generator: false
   social:

--- a/tests/fixtures/ai-assistant.html
+++ b/tests/fixtures/ai-assistant.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <title>1. 两数之和</title>
+  <link rel="stylesheet" href="../../docs/stylesheets/ai-assistant.css">
+  <style>
+    :root {
+      --md-default-fg-color: #111;
+      --md-default-bg-color: #fff;
+      --md-accent-fg-color: #4051b5;
+      --md-primary-fg-color: #4051b5;
+      --md-default-fg-color--light: #555;
+      --md-default-fg-color--lightest: #ddd;
+    }
+    body { font-family: sans-serif; margin: 0; }
+    .md-header__inner { display: flex; justify-content: flex-end; padding: 8px 16px; border-bottom: 1px solid #ddd; }
+    .md-content { padding: 16px 24px; max-width: 720px; }
+  </style>
+  <script type="application/json" id="doocs-ai-config">
+    {"lang":"zh","title":"1. 两数之和","url":"lc/1/","defaultProvider":"deepseek","providers":[{"id":"deepseek","name":"DeepSeek","base_url":"https://api.deepseek.com/v1","models":["deepseek-chat"]},{"id":"custom","name":"Custom","base_url":"","models":[]}],"plugin":true}
+  </script>
+</head>
+<body>
+  <header class="md-header"><div class="md-header__inner"></div></header>
+  <article class="md-content">
+    <div class="md-content__inner">
+      <h1>1. 两数之和</h1>
+      <p>给定一个整数数组 nums 和一个整数目标值 target，请你在该数组中找出和为目标值的那两个整数。</p>
+      <div class="tabbed-set">
+        <input type="radio" id="tab-py" name="lang" checked>
+        <label for="tab-py">Python3</label>
+        <div class="tabbed-content">
+          <div class="tabbed-block">
+            <div class="highlight">
+              <pre><code>class Solution:
+    def twoSum(self, nums, target):
+        d = {}
+        for i, x in enumerate(nums):
+            if target - x in d:
+                return [d[target - x], i]
+            d[x] = i
+</code></pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </article>
+  <script src="../../docs/javascripts/ai-assistant.js"></script>
+</body>
+</html>

--- a/tests/test_ai_assistant.py
+++ b/tests/test_ai_assistant.py
@@ -1,0 +1,109 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+import ai_assistant as ai  # noqa: E402
+
+PAGE = SimpleNamespace(url="lc/1/", title="1. 两数之和")
+HEAD = "<html><head><title>x</title></head><body>hi</body></html>"
+ASSETS = (
+    '<script src="../javascripts/ai-assistant.js"></script>'
+    '<link rel="stylesheet" href="../stylesheets/ai-assistant.css">'
+)
+MINIFIED = (
+    "<script src=../javascripts/ai-assistant.js></script>"
+    "<link rel=stylesheet href=../stylesheets/ai-assistant.css>"
+)
+
+
+class AiAssistantHookTest(unittest.TestCase):
+    def test_enabled_by_default(self):
+        self.assertTrue(ai.is_enabled({}))
+        self.assertTrue(ai.is_enabled({"extra": {}}))
+        self.assertTrue(ai.is_enabled({"extra": {"ai": {}}}))
+
+    def test_can_disable(self):
+        self.assertFalse(ai.is_enabled({"extra": {"ai": {"enabled": False}}}))
+        self.assertFalse(ai.is_enabled({"extra": {"ai": False}}))
+
+    def test_injects_config_when_enabled(self):
+        out = ai.on_post_page(HEAD, PAGE, {"site_url": "https://leetcode.doocs.org"})
+        self.assertIn('id="doocs-ai-config"', out)
+        raw = out.split('id="doocs-ai-config">', 1)[1].split("</script>", 1)[0]
+        payload = json.loads(raw)
+        self.assertEqual(payload["lang"], "zh")
+        self.assertEqual(payload["title"], "1. 两数之和")
+        self.assertEqual(payload["url"], "lc/1/")
+        self.assertEqual(payload["defaultProvider"], "deepseek")
+        self.assertTrue(payload["providers"])
+
+    def test_en_site_uses_en_lang(self):
+        out = ai.on_post_page(
+            HEAD,
+            PAGE,
+            {"site_url": "https://leetcode.doocs.org/en", "site_dir": "site/en"},
+        )
+        raw = out.split('id="doocs-ai-config">', 1)[1].split("</script>", 1)[0]
+        self.assertEqual(json.loads(raw)["lang"], "en")
+
+    def test_does_not_double_inject(self):
+        first = ai.on_post_page(HEAD, PAGE, {})
+        second = ai.on_post_page(first, PAGE, {})
+        self.assertEqual(first.count("doocs-ai-config"), 1)
+        self.assertEqual(second.count("doocs-ai-config"), 1)
+
+    def test_disabled_strips_assets(self):
+        html = HEAD.replace("</head>", ASSETS + "</head>")
+        out = ai.on_post_page(html, PAGE, {"extra": {"ai": {"enabled": False}}})
+        self.assertNotIn("ai-assistant.js", out)
+        self.assertNotIn("ai-assistant.css", out)
+        self.assertNotIn("doocs-ai-config", out)
+        self.assertIn("hi", out)
+
+    def test_disabled_strips_minified_assets(self):
+        html = "<html><head>" + MINIFIED + "</head><body></body></html>"
+        out = ai.on_post_page(html, PAGE, {"extra": {"ai": False}})
+        self.assertNotIn("ai-assistant", out)
+
+    def test_empty_output(self):
+        self.assertEqual(ai.on_post_page("", PAGE, {}), "")
+
+    def test_custom_providers(self):
+        config = {
+            "extra": {
+                "ai": {
+                    "default_provider": "custom",
+                    "providers": [
+                        {
+                            "id": "custom",
+                            "name": "Mine",
+                            "base_url": "https://proxy.example/v1",
+                            "models": ["demo"],
+                        }
+                    ],
+                }
+            }
+        }
+        payload = ai.build_config(PAGE, config)
+        self.assertEqual(payload["defaultProvider"], "custom")
+        self.assertEqual(payload["providers"][0]["base_url"], "https://proxy.example/v1")
+
+
+class AiAssistantAssetsTest(unittest.TestCase):
+    def test_cn_and_en_assets_match(self):
+        for name in (
+            "javascripts/ai-assistant.js",
+            "stylesheets/ai-assistant.css",
+        ):
+            cn = (ROOT / "docs" / name).read_text(encoding="utf-8")
+            en = (ROOT / "docs-en" / name).read_text(encoding="utf-8")
+            self.assertEqual(cn, en)
+            self.assertTrue(cn.strip())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ai_assistant.py
+++ b/tests/test_ai_assistant.py
@@ -39,6 +39,7 @@ class AiAssistantHookTest(unittest.TestCase):
         self.assertEqual(payload["title"], "1. 两数之和")
         self.assertEqual(payload["url"], "lc/1/")
         self.assertEqual(payload["defaultProvider"], "deepseek")
+        self.assertEqual(payload["endpoint"], "")
         self.assertTrue(payload["providers"])
 
     def test_en_site_uses_en_lang(self):
@@ -91,6 +92,12 @@ class AiAssistantHookTest(unittest.TestCase):
         payload = ai.build_config(PAGE, config)
         self.assertEqual(payload["defaultProvider"], "custom")
         self.assertEqual(payload["providers"][0]["base_url"], "https://proxy.example/v1")
+
+    def test_endpoint_from_extra(self):
+        payload = ai.build_config(
+            PAGE, {"extra": {"ai": {"endpoint": "https://ai.example/chat"}}}
+        )
+        self.assertEqual(payload["endpoint"], "https://ai.example/chat")
 
 
 class AiAssistantAssetsTest(unittest.TestCase):

--- a/workers/ai-proxy/README.md
+++ b/workers/ai-proxy/README.md
@@ -1,0 +1,26 @@
+# Doocs LeetCode AI proxy
+
+站点内置问答的服务端。用户不用填 Key；Key 只放在 Cloudflare Worker 密钥里。
+
+```bash
+cd workers/ai-proxy
+npx wrangler secret put AI_API_KEY
+npx wrangler deploy
+```
+
+把部署后的地址写进 `mkdocs.yml`：
+
+```yaml
+extra:
+  ai:
+    enabled: true
+    endpoint: https://doocs-leetcode-ai.<your-subdomain>.workers.dev/chat
+```
+
+本地预览：
+
+```bash
+npx wrangler dev --port 8787
+```
+
+页面在 `127.0.0.1` 时会自动走 `http://127.0.0.1:8787/chat`。

--- a/workers/ai-proxy/src/index.js
+++ b/workers/ai-proxy/src/index.js
@@ -1,0 +1,159 @@
+const ALLOW_HOSTS = [
+  "leetcode.doocs.org",
+  "doocs.gitee.io",
+  "127.0.0.1",
+  "localhost",
+];
+
+function originAllowed(origin) {
+  if (!origin) {
+    return false;
+  }
+  try {
+    const host = new URL(origin).hostname;
+    return ALLOW_HOSTS.some((item) => host === item || host.endsWith(`.${item}`));
+  } catch {
+    return false;
+  }
+}
+
+function corsHeaders(request) {
+  const origin = request.headers.get("Origin") || "";
+  const headers = {
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Max-Age": "86400",
+  };
+  if (originAllowed(origin)) {
+    headers["Access-Control-Allow-Origin"] = origin;
+    headers.Vary = "Origin";
+  }
+  return headers;
+}
+
+function json(request, body, status) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      ...corsHeaders(request),
+    },
+  });
+}
+
+function clip(text, max) {
+  return String(text || "").trim().slice(0, max);
+}
+
+function buildMessages(body) {
+  const lang = body.lang === "en" ? "en" : "zh";
+  const langLine =
+    lang === "en"
+      ? "Answer in concise English. Explain the solution already on this page. Do not invent a new solution or problem numbers."
+      : "用简洁的中文回答。解释本站已经写好的题解，不要另编一套题解，也不要编造不存在的题号。";
+  const system = [
+    "You are the built-in helper for Doocs LeetCode Wiki.",
+    langLine,
+    "Ground every claim in the provided page context. If something is missing, say so.",
+    "Prefer hints and walkthroughs of the existing code over dumping a replacement.",
+    `Page title: ${clip(body.title, 200)}`,
+    `Page URL: ${clip(body.url, 300)}`,
+    `Active language tab: ${clip(body.langTab, 40) || "(none)"}`,
+  ].join("\n");
+  const context = [
+    `Page excerpt:\n${clip(body.excerpt, 5000) || "(empty)"}`,
+    `Current solution (${clip(body.langTab, 40) || "code"}):\n${clip(body.code, 8000) || "(none)"}`,
+    body.selection ? `User selection:\n${clip(body.selection, 4000)}` : "",
+    body.mine ? `User's own code:\n${clip(body.mine, 8000)}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+  return [
+    { role: "system", content: system },
+    { role: "user", content: context },
+    { role: "user", content: clip(body.query, 2000) },
+  ];
+}
+
+async function rateLimited(request, env) {
+  const ip = request.headers.get("CF-Connecting-IP") || "local";
+  const hour = Math.floor(Date.now() / 3600000);
+  const url = new URL(`https://doocs-ai-rate.invalid/${ip}/${hour}`);
+  const cache = caches.default;
+  const hit = await cache.match(url);
+  const used = hit ? Number(await hit.text()) : 0;
+  const limit = Number(env.RATE_LIMIT || 30);
+  if (used >= limit) {
+    return true;
+  }
+  await cache.put(
+    url,
+    new Response(String(used + 1), {
+      headers: { "Cache-Control": "max-age=3600" },
+    })
+  );
+  return false;
+}
+
+export default {
+  async fetch(request, env) {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: corsHeaders(request) });
+    }
+    const path = new URL(request.url).pathname.replace(/\/$/, "") || "/";
+    if (path !== "/chat") {
+      return json(request, { error: "not found" }, 404);
+    }
+    if (request.method !== "POST") {
+      return json(request, { error: "method not allowed" }, 405);
+    }
+    const origin = request.headers.get("Origin") || "";
+    if (origin && !originAllowed(origin)) {
+      return json(request, { error: "forbidden" }, 403);
+    }
+    if (!env.AI_API_KEY) {
+      return json(request, { error: "AI_API_KEY is not configured" }, 503);
+    }
+    if (await rateLimited(request, env)) {
+      return json(request, { error: "rate limited" }, 429);
+    }
+
+    let body;
+    try {
+      body = await request.json();
+    } catch {
+      return json(request, { error: "invalid json" }, 400);
+    }
+    if (!clip(body && body.query, 2000)) {
+      return json(request, { error: "query required" }, 400);
+    }
+
+    const base = String(env.AI_BASE_URL || "https://api.deepseek.com/v1").replace(
+      /\/$/,
+      ""
+    );
+    const upstream = await fetch(`${base}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.AI_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: env.AI_MODEL || "deepseek-chat",
+        stream: true,
+        temperature: 0.3,
+        messages: buildMessages(body),
+      }),
+    });
+
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: {
+        "Content-Type":
+          upstream.headers.get("Content-Type") || "text/event-stream",
+        "Cache-Control": "no-store",
+        ...corsHeaders(request),
+      },
+    });
+  },
+};

--- a/workers/ai-proxy/wrangler.jsonc
+++ b/workers/ai-proxy/wrangler.jsonc
@@ -1,0 +1,10 @@
+{
+  "name": "doocs-leetcode-ai",
+  "main": "src/index.js",
+  "compatibility_date": "2026-09-07",
+  "vars": {
+    "AI_BASE_URL": "https://api.deepseek.com/v1",
+    "AI_MODEL": "deepseek-chat",
+    "RATE_LIMIT": "30"
+  }
+}


### PR DESCRIPTION
## Summary
- Add an optional Ask AI side panel on docs pages (header button, `Ctrl/Cmd+I`, highlight-to-ask, code-block action).
- Providers are pluggable: DeepSeek / Qwen / SiliconFlow / OpenAI / Ollama / custom OpenAI-compatible endpoints. The API key stays in the browser.
- Optional Chromium extension `extensions/doocs-ai` forwards chat requests so model APIs are not blocked by CORS.
- Turn the whole feature off with `extra.ai.enabled: false`.

## Test plan
- [x] `python -m unittest tests.test_ai_assistant -v`
- [x] Local fixture: panel opens, settings fill DeepSeek defaults, missing key shows a clear error
- [ ] After deploy, open `/lc/1/`: header has Ask AI; language switcher and comments still work
- [ ] Load `extensions/doocs-ai` unpacked, reload the page, status says the plugin is connected
- [ ] Paste a key and ask `这题在考什么？` — answer stays on the current problem
- [ ] Set `extra.ai.enabled: false` and confirm the panel assets disappear

Made with [Cursor](https://cursor.com)