### PR TITLE
ci: deploy the built site to Cloudflare Workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -351,7 +351,7 @@ jobs:
           set -euo pipefail
           for f in site/search/search_index.json site/en/search/search_index.json; do
             if [ -f "$f" ]; then
-              gzip -9 -c "$f" > "${f}.gz"
+              gzip -9n -c "$f" > "${f}.gz"
               rm -f "$f"
             fi
           done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -317,3 +317,48 @@ jobs:
           chmod 700 "$ASKPASS"
           GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0 \
             git push -f https://oauth2@gitee.com/Doocs/leetcode.git HEAD:pages
+
+  deploy-cloudflare:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.repository == 'doocs/leetcode'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            wrangler.jsonc
+            worker.js
+
+      - name: Download Chinese site
+        uses: actions/download-artifact@v8
+        with:
+          name: site-zh
+          path: site
+
+      - name: Download English site
+        uses: actions/download-artifact@v8
+        with:
+          name: site-en
+          path: site/en
+
+      - name: Compress search indexes over the 25 MiB asset limit
+        run: |
+          set -euo pipefail
+          for f in site/search/search_index.json site/en/search/search_index.json; do
+            if [ -f "$f" ]; then
+              gzip -9 -c "$f" > "${f}.gz"
+              rm -f "$f"
+            fi
+          done
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ npm-debug.log*
 /solution/.env
 .cache
 .preview/
+/site
+.wrangler/
 !.cache/plugin/
 !.cache/plugin/git-committers/
 !.cache/plugin/git-committers/page-authors.json

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,22 @@
+export default {
+    async fetch(request, env) {
+        const url = new URL(request.url);
+        if (url.pathname.endsWith('/search/search_index.json')) {
+            const asset = await env.ASSETS.fetch(
+                new Request(new URL(`${url.pathname}.gz`, url.origin), request),
+            );
+            if (asset.ok) {
+                const headers = new Headers(asset.headers);
+                headers.set('Content-Type', 'application/json; charset=utf-8');
+                headers.set('Content-Encoding', 'gzip');
+                headers.set('Cache-Control', 'public, max-age=3600');
+                return new Response(asset.body, {
+                    status: 200,
+                    headers,
+                    encodeBody: 'manual',
+                });
+            }
+        }
+        return env.ASSETS.fetch(request);
+    },
+};

--- a/worker.js
+++ b/worker.js
@@ -5,13 +5,15 @@ export default {
             const asset = await env.ASSETS.fetch(
                 new Request(new URL(`${url.pathname}.gz`, url.origin), request),
             );
-            if (asset.ok) {
+            if (asset.ok || asset.status === 304) {
                 const headers = new Headers(asset.headers);
                 headers.set('Content-Type', 'application/json; charset=utf-8');
-                headers.set('Content-Encoding', 'gzip');
                 headers.set('Cache-Control', 'public, max-age=3600');
+                if (asset.status !== 304) {
+                    headers.set('Content-Encoding', 'gzip');
+                }
                 return new Response(asset.body, {
-                    status: 200,
+                    status: asset.status,
                     headers,
                     encodeBody: 'manual',
                 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,12 @@
+{
+  "name": "leetcode",
+  "main": "worker.js",
+  "compatibility_date": "2026-09-07",
+  "workers_dev": true,
+  "assets": {
+    "directory": "./site",
+    "binding": "ASSETS",
+    "not_found_handling": "404-page",
+    "run_worker_first": ["/search/*", "/en/search/*"]
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,9 @@
     "directory": "./site",
     "binding": "ASSETS",
     "not_found_handling": "404-page",
-    "run_worker_first": ["/search/*", "/en/search/*"]
+    "run_worker_first": [
+      "/search/search_index.json",
+      "/en/search/search_index.json"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Add a `deploy-cloudflare` job that publishes the MkDocs `site/` artifact as Workers static assets.
- Gzip the oversized search indexes and serve them from a small Worker so they stay under the 25 MiB asset limit.
- Leave GitHub Pages and Gitee Pages as they are; the Worker URL is https://leetcode.doocs.workers.dev.

## Test plan
- [x] Local `wrangler deploy` succeeded; homepage and `/lc/1/` load on https://leetcode.doocs.workers.dev
- [x] Search index fetches as JSON after gzip + `encodeBody: manual`
- [ ] Confirm `deploy.yml` on `main` runs `deploy-cloudflare` after merge (uses org `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`)
- [ ] Confirm GitHub Pages and Gitee Pages still publish as before