### PR TITLE
fix: decompress gzipped search indexes in the Cloudflare Worker

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -2,20 +2,29 @@ export default {
     async fetch(request, env) {
         const url = new URL(request.url);
         if (url.pathname.endsWith('/search/search_index.json')) {
+            const headers = new Headers(request.headers);
+            headers.delete('Accept-Encoding');
             const asset = await env.ASSETS.fetch(
-                new Request(new URL(`${url.pathname}.gz`, url.origin), request),
-            );
-            if (asset.ok || asset.status === 304) {
-                const headers = new Headers(asset.headers);
-                headers.set('Content-Type', 'application/json; charset=utf-8');
-                headers.set('Cache-Control', 'public, max-age=3600');
-                if (asset.status !== 304) {
-                    headers.set('Content-Encoding', 'gzip');
-                }
-                return new Response(asset.body, {
-                    status: asset.status,
+                new Request(new URL(`${url.pathname}.gz`, url.origin), {
+                    method: request.method,
                     headers,
-                    encodeBody: 'manual',
+                }),
+            );
+            if (asset.status === 304) {
+                return new Response(null, {
+                    status: 304,
+                    headers: asset.headers,
+                });
+            }
+            if (asset.ok && asset.body) {
+                const out = new Headers(asset.headers);
+                out.set('Content-Type', 'application/json; charset=utf-8');
+                out.set('Cache-Control', 'public, max-age=3600');
+                out.delete('Content-Encoding');
+                out.delete('Content-Length');
+                return new Response(asset.body.pipeThrough(new DecompressionStream('gzip')), {
+                    status: asset.status,
+                    headers: out,
                 });
             }
         }

--- a/worker.js
+++ b/worker.js
@@ -10,19 +10,17 @@ export default {
                     headers,
                 }),
             );
-            if (asset.status === 304) {
-                return new Response(null, {
-                    status: 304,
-                    headers: asset.headers,
-                });
-            }
-            if (asset.ok && asset.body) {
+            if (asset.status === 304 || asset.ok) {
                 const out = new Headers(asset.headers);
                 out.set('Content-Type', 'application/json; charset=utf-8');
                 out.set('Cache-Control', 'public, max-age=3600');
                 out.delete('Content-Encoding');
                 out.delete('Content-Length');
-                return new Response(asset.body.pipeThrough(new DecompressionStream('gzip')), {
+                const body =
+                    asset.status === 304 || request.method === 'HEAD' || !asset.body
+                        ? null
+                        : asset.body.pipeThrough(new DecompressionStream('gzip'));
+                return new Response(body, {
                     status: asset.status,
                     headers: out,
                 });


### PR DESCRIPTION
## Summary
- Search indexes over Cloudflare's 25 MiB asset limit are stored as `search_index.json.gz`. The Worker used to return those gzip bytes with `Content-Encoding: gzip` and `encodeBody: 'manual'`.
- MkDocs Material `JSON.parse`s `search_index.json`. On workers.dev the browser does not decode that encoding, so the console throws `Unexpected token '\u001f'` (gzip magic bytes).
- Decompress the gzip stream in the Worker and return JSON so Cloudflare can apply normal content encoding for the client.

## Test plan
- [ ] Deploy the Worker and open https://leetcode.doocs.workers.dev/
- [ ] Confirm the console no longer reports `JSON.parse` / `Unexpected token` on `search_index.json`
- [ ] Confirm site search returns results for Chinese and English (`/search/search_index.json` and `/en/search/search_index.json`)
- [ ] Confirm `/search/search_index.json` is valid JSON (starts with `{`, not gzip `1f 8b`)

Made with [Cursor](https://cursor.com)