### PR TITLE
ci: use kebab-case workflow names that match filenames

### DIFF
--- a/.github/workflows/black-lint.yml
+++ b/.github/workflows/black-lint.yml
@@ -1,4 +1,4 @@
-name: black-linter
+name: black-lint
 
 on:
   push:
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -1,4 +1,4 @@
-name: clang-format-linter
+name: clang-format-lint
 
 on:
   push:
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/compress-images.yml
+++ b/.github/workflows/compress-images.yml
@@ -7,6 +7,7 @@ on:
       - '**.jpeg'
       - '**.png'
       - '**.webp'
+      - .github/workflows/compress-images.yml
   push:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
       - '**.jpeg'
       - '**.png'
       - '**.webp'
+      - .github/workflows/compress-images.yml
   workflow_dispatch:
   schedule:
     - cron: '00 23 * * 0'
@@ -25,8 +27,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: calibreapp/image-actions
+  compress:
     runs-on: ubuntu-latest
     # Only run on main repo on and PRs that match the main repo.
     if: |
@@ -34,16 +35,16 @@ jobs:
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
-      - name: Checkout Branch
+      - name: Checkout branch
         uses: actions/checkout@v7
-      - name: Compress Images
+      - name: Compress images
         id: calibre
         uses: calibreapp/image-actions@9d037c06280028c110ff61c433ad4dc7d33c3c43 # v1.5.0
         with:
           githubToken: ${{ secrets.DOOCS_BOT_ACTION_TOKEN }}
           # For non-Pull Requests, run in compressOnly mode and we'll PR after.
           compressOnly: ${{ github.event_name != 'pull_request' }}
-      - name: Create Pull Request
+      - name: Create pull request
         # If it's not a Pull Request then commit any changes as a new PR.
         if: |
           github.event_name != 'pull_request' &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
           path: mkdocs
           fetch-depth: 1
 
-      - name: Setup Python
+      - name: Set up Python
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
@@ -125,7 +125,7 @@ jobs:
           name: prepared-site
           path: .
 
-      - name: Setup Python
+      - name: Set up Python
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'

--- a/.github/workflows/gofmt-lint.yml
+++ b/.github/workflows/gofmt-lint.yml
@@ -1,4 +1,4 @@
-name: gofmt-linter
+name: gofmt-lint
 
 on:
   push:
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/pr-add-label.yml
+++ b/.github/workflows/pr-add-label.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, reopened, synchronize]
 
 # Labels external PRs via the GitHub API only. Do not check out PR code here.
-# Fork PRs must still run; prettier.yml is the workflow that skips forks.
+# Fork PRs must still run; prettier-write.yml is the workflow that skips forks.
 
 permissions:
   contents: read
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'doocs/leetcode'
     steps:
-      - name: Run add-label Action
+      - name: Run add-label action
         uses: actionv/pr-label-action@907fc236390396b7a1198624d6b26241cfc25fa3 # master
         with:
           github_token: ${{ secrets.DOOCS_BOT_ACTION_TOKEN }}

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -15,11 +15,11 @@ permissions:
   issues: write
 
 jobs:
-  build:
+  check:
     if: github.repository == 'doocs/leetcode'
     runs-on: ubuntu-latest
     steps:
-      - name: Check Team Membership
+      - name: Check team membership
         id: check_team
         env:
           PR_OPENER: ${{ github.actor }}

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -1,4 +1,4 @@
-name: PR Labeled
+name: pr-labeled
 
 on:
   pull_request_target:
@@ -10,7 +10,7 @@ permissions:
   issues: write
 
 jobs:
-  issue-labeled:
+  labeled:
     if: github.repository == 'doocs/leetcode'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 24
-      - name: Install Dependencies
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Check prettier
         run: |

--- a/.github/workflows/prettier-write.yml
+++ b/.github/workflows/prettier-write.yml
@@ -1,4 +1,4 @@
-name: prettier
+name: prettier-write
 
 on:
   pull_request_target:
@@ -20,7 +20,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24
-      - name: Install Dependencies
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Run prettier
         run: |

--- a/.github/workflows/rustfmt-lint.yml
+++ b/.github/workflows/rustfmt-lint.yml
@@ -1,4 +1,4 @@
-name: rustfmt-linter
+name: rustfmt-lint
 
 on:
   push:
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/update-starcharts.yml
+++ b/.github/workflows/update-starcharts.yml
@@ -13,8 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  update-readme:
-    name: Generate starcharts
+  update:
     runs-on: ubuntu-latest
     if: github.repository == 'doocs/leetcode'
     steps:


### PR DESCRIPTION
## Summary
- Use one convention: lowercase kebab-case, and `name` equals the filename without `.yml`.
- Rename `compress.yml` → `compress-images.yml`, `starcharts.yml` → `update-starcharts.yml`, `prettier.yml` → `prettier-write.yml`.
- Drop the `*-linter` / `PR Labeled` outliers, and align job ids (`lint`, `check`, `compress`, `update`, `labeled`) with each workflow.

## Test plan
- [ ] Actions tab lists the new kebab-case workflow names
- [ ] Same-repo PRs still run `prettier-write`; all PRs still run `prettier-check`
- [ ] Language linters still fire on their file types (`black-lint`, `clang-format-lint`, `gofmt-lint`, `rustfmt-lint`)
- [ ] `deploy-request` still dispatches `deploy.yml`

Made with [Cursor](https://cursor.com)