### PR TITLE
ci: harden deploy triggers, caches, and formatter alignment

### DIFF
--- a/.github/workflows/black-lint.yml
+++ b/.github/workflows/black-lint.yml
@@ -35,6 +35,8 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+          cache: pip
+          cache-dependency-path: requirements.txt
       - name: Install black
         run: |
           set -euo pipefail

--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -8,6 +8,7 @@ on:
       - '**/*.cpp'
       - '**/*.java'
       - .clang-format
+      - requirements.txt
       - .github/workflows/clang-format-lint.yml
       - .github/scripts/fetch-diff-base.sh
   pull_request:
@@ -16,6 +17,7 @@ on:
       - '**/*.cpp'
       - '**/*.java'
       - .clang-format
+      - requirements.txt
       - .github/workflows/clang-format-lint.yml
       - .github/scripts/fetch-diff-base.sh
 
@@ -36,8 +38,20 @@ jobs:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GIT_BEFORE: ${{ github.event.before }}
         run: bash .github/scripts/fetch-diff-base.sh
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: requirements.txt
       - name: Install clang-format
-        run: python3 -m pip install clang-format==23.1.0
+        run: |
+          set -euo pipefail
+          pin="$(grep '^clang-format==' requirements.txt || true)"
+          if [ -z "$pin" ]; then
+            echo "requirements.txt must contain a clang-format== version pin."
+            exit 1
+          fi
+          python -m pip install "$pin"
       - name: Check clang-format
         run: |
           set -euo pipefail

--- a/.github/workflows/deploy-request.yml
+++ b/.github/workflows/deploy-request.yml
@@ -12,6 +12,8 @@ on:
       - lcof/**
       - lcci/**
       - basic/**
+      - worker.js
+      - wrangler.jsonc
 
 concurrency:
   group: deploy-request

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,7 +194,6 @@ jobs:
         run: echo "leetcode.doocs.org" > ./site/CNAME
 
       - name: Download committer caches
-        if: github.event_name != 'pull_request'
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
@@ -203,7 +202,6 @@ jobs:
           merge-multiple: false
 
       - name: Commit merged committer cache to docs branch
-        if: github.event_name != 'pull_request'
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-add-label.yml
+++ b/.github/workflows/pr-add-label.yml
@@ -7,6 +7,10 @@ on:
 # Labels external PRs via the GitHub API only. Do not check out PR code here.
 # Fork PRs must still run; prettier-write.yml is the workflow that skips forks.
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -98,18 +98,18 @@ jobs:
                     if (isTeamMember) {
                         console.log(`The user ${PR_OPENER} is a member of the team. Terminating with the workflow.`);
                         return
-                    } else {
-                      console.log(`The user ${PR_OPENER} is not a member of the team. Proceeding the workflow.`);
-                      github.rest.issues.createComment({
-                        issue_number: context.issue.number,
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        body: comment
-                      })
                     }
+                    console.log(`The user ${PR_OPENER} is not a member of the team. Proceeding the workflow.`);
+                    await github.rest.issues.createComment({
+                      issue_number: context.issue.number,
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      body: comment
+                    })
                   } catch (error) {
                     console.log(PR_OPENER)
                     console.log(error)
+                    throw error
                   }
                   }
-                  checkTeamMembership();
+                  await checkTeamMembership();

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -43,7 +43,14 @@ jobs:
         run: |
           set -euo pipefail
           git config core.quotepath false
-          mapfile -t files < <(git -c core.quotepath=false diff --name-only --diff-filter=ACMR "${{ github.event.pull_request.base.sha }}" -- '*.js' '*.ts' '*.php' '*.sql' '*.md' || true)
+          base="${{ github.event.pull_request.base.sha }}"
+          mapfile -t config_files < <(git -c core.quotepath=false diff --name-only --diff-filter=ACMR "$base" -- .prettierrc .prettierignore package.json pnpm-lock.yaml || true)
+          if [ ${#config_files[@]} -gt 0 ]; then
+            echo "Prettier config or dependencies changed; checking all matching files."
+            pnpm exec prettier --check "**/*.{js,ts,php,sql,md}"
+            exit 0
+          fi
+          mapfile -t files < <(git -c core.quotepath=false diff --name-only --diff-filter=ACMR "$base" -- '*.js' '*.ts' '*.php' '*.sql' '*.md' || true)
           if [ ${#files[@]} -eq 0 ]; then
             echo "No Prettier files changed."
             exit 0

--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -9,6 +9,7 @@ on:
       - '**/*.php'
       - '**/*.sql'
       - '**/*.md'
+      - .prettierrc
       - .prettierignore
       - package.json
       - pnpm-lock.yaml
@@ -35,6 +36,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 24
+          cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Check prettier

--- a/.github/workflows/prettier-write.yml
+++ b/.github/workflows/prettier-write.yml
@@ -3,6 +3,17 @@ name: prettier-write
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
+    paths:
+      - '**/*.js'
+      - '**/*.ts'
+      - '**/*.php'
+      - '**/*.sql'
+      - '**/*.md'
+      - .prettierrc
+      - .prettierignore
+      - package.json
+      - pnpm-lock.yaml
+      - .github/workflows/prettier-write.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -32,6 +43,7 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24
+          cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Run prettier

--- a/.github/workflows/prettier-write.yml
+++ b/.github/workflows/prettier-write.yml
@@ -51,7 +51,14 @@ jobs:
           set -euo pipefail
           git config --global core.quotepath off
           git fetch --depth=1 origin "${{ github.event.pull_request.base.sha }}"
-          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "${{ github.event.pull_request.base.sha }}" -- '*.js' '*.ts' '*.php' '*.sql' '*.md' || true)
+          base="${{ github.event.pull_request.base.sha }}"
+          mapfile -t config_files < <(git diff --name-only --diff-filter=ACMR "$base" -- .prettierrc .prettierignore package.json pnpm-lock.yaml || true)
+          if [ ${#config_files[@]} -gt 0 ]; then
+            echo "Prettier config or dependencies changed; formatting all matching files."
+            pnpm exec prettier --write "**/*.{js,ts,php,sql,md}"
+            exit 0
+          fi
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "$base" -- '*.js' '*.ts' '*.php' '*.sql' '*.md' || true)
           if [ ${#files[@]} -eq 0 ]; then
             echo "No matching files to run prettier on."
             exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ npm-debug.log*
 .cache
 .preview/
 /site
+/site-artifacts
 .wrangler/
 !.cache/plugin/
 !.cache/plugin/git-committers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ This is [doocs/leetcode](https://github.com/doocs/leetcode) — a large collecti
 - **`main`** — problem sources, lint tooling, and deploy workflows.
 - **`docs`** — MkDocs site engine only (`build_site.py`, `mkdocs.yml`, `hooks/`, `overrides/`). Problem pages are generated at deploy time from `main`.
 
-Deploy checks out both branches, overlays a whitelist from `docs` onto `main`, runs `python3 build_site.py`, then builds zh/en in parallel. Content pushes on `main` go through `deploy-request.yml` (about 90s quiet period, then `gh workflow run deploy.yml`). Pushes to `docs` use `.github/workflows/trigger-deploy.yml` the same way. A started `deploy.yml` run is not cancelled.
+Deploy checks out both branches, overlays a whitelist from `docs` onto `main`, runs `python3 build_site.py`, then builds zh/en in parallel. Content pushes on `main` (problem trees, `worker.js`, and `wrangler.jsonc`) go through `deploy-request.yml` (about 90s quiet period, then `gh workflow run deploy.yml`). Pushes to `docs` use `.github/workflows/trigger-deploy.yml` on the `docs` branch the same way. A started `deploy.yml` run is not cancelled.
 
 Dependabot updates npm, GitHub Actions, and pip on `main`, and pip on `docs`.
 
@@ -57,7 +57,7 @@ node scripts/run-py.js run_format.py --clang-format <file>
 node scripts/run-py.js run_format.py --gofmt <file>
 
 # Rust
-rustfmt <file>
+rustfmt --edition 2021 <file>
 ```
 
 Or run the full formatting script:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "*.py": "node scripts/run-py.js -m black -S",
     "*.{c,cpp,java}": "node scripts/run-py.js run_format.py --clang-format",
     "*.go": "node scripts/run-py.js run_format.py --gofmt",
-    "*.rs": "rustfmt"
+    "*.rs": "rustfmt --edition 2021"
   },
   "packageManager": "pnpm@11.25.0"
 }

--- a/run_format.py
+++ b/run_format.py
@@ -271,17 +271,19 @@ def remove_header(path: str, quiet: bool = False):
 
 def find_all_paths() -> List[str]:
     """Find all paths of files with suffixes"""
+    skip_dirs = {
+        "node_modules",
+        "__pycache__",
+        ".git",
+        ".preview",
+        "site-artifacts",
+        "site",
+    }
     paths = []
-    for root, _, files in os.walk(os.getcwd()):
+    for root, dirs, files in os.walk(os.getcwd()):
+        dirs[:] = [d for d in dirs if d not in skip_dirs]
         for file in files:
             path = root + "/" + file
-            if (
-                "node_modules" in path
-                or "__pycache__" in path
-                or ".git" in path
-                or ".preview" in path.replace("\\", "/")
-            ):
-                continue
             if any(path.endswith(f".{suf}") for suf in suffixes):
                 paths.append(path)
     return paths


### PR DESCRIPTION
## Summary
- Dispatch site deploys when `worker.js` or `wrangler.jsonc` change, so Worker-only fixes no longer sit undeployed.
- Ignore `site-artifacts/` and skip `site` / `site-artifacts` in `run_format.py`.
- Give `prettier-write` the same path filters as `prettier-check`, cache pnpm/pip, and read the clang-format pin from `requirements.txt`.
- Await the PR-checker comment, add concurrency to `pr-add-label`, and run local rustfmt with `--edition 2021`.
- Drop dead `pull_request` guards in `deploy.yml` and note that `trigger-deploy.yml` lives on the `docs` branch.

## Test plan
- [ ] Merge a `worker.js`-only change to `main` and confirm `deploy-request` runs
- [ ] Open a Python-only PR and confirm `prettier-write` is skipped
- [ ] Confirm `clang-format-lint` still installs the pin from `requirements.txt`
- [ ] Confirm a fork PR still gets the guidelines comment from `pr-checker`
- [ ] `git status` no longer lists `site-artifacts/`

Made with [Cursor](https://cursor.com)