### PR TITLE
docs: split problem 2361 rolling DP into method 2

### DIFF
--- a/solution/2300-2399/2361.Minimum Costs Using the Train Line/README.md
+++ b/solution/2300-2399/2361.Minimum Costs Using the Train Line/README.md
@@ -214,7 +214,13 @@ function minimumCosts(regular: number[], express: number[], expressCost: number)
 
 <!-- tabs:end -->
 
-我们注意到 $f[i]$ 和 $g[i]$ 的状态转移方程中，我们只需要用到 $f[i-1]$ 和 $g[i-1]$，因此我们可以使用两个变量 $f$ 和 $g$ 分别记录 $f[i-1]$ 和 $g[i-1]$ 的值，这样可以将空间复杂度优化到 $O(1)$。
+<!-- solution:end -->
+
+<!-- solution:start -->
+
+### 方法二：动态规划优化
+
+我们注意到 $f[i]$ 和 $g[i]$ 只依赖 $f[i-1]$ 和 $g[i-1]$，因此可以用两个变量滚动更新，将额外空间优化到 $O(1)$。
 
 <!-- tabs:start -->
 

--- a/solution/2300-2399/2361.Minimum Costs Using the Train Line/README_EN.md
+++ b/solution/2300-2399/2361.Minimum Costs Using the Train Line/README_EN.md
@@ -212,7 +212,13 @@ function minimumCosts(regular: number[], express: number[], expressCost: number)
 
 <!-- tabs:end -->
 
-We notice that in the state transition equations of $f[i]$ and $g[i]$, we only need to use $f[i-1]$ and $g[i-1]$. Therefore, we can use two variables $f$ and $g$ to record the values of $f[i-1]$ and $g[i-1]$ respectively. This allows us to optimize the space complexity to $O(1)$.
+<!-- solution:end -->
+
+<!-- solution:start -->
+
+### Solution 2: Optimized Dynamic Programming
+
+$f[i]$ and $g[i]$ only depend on $f[i-1]$ and $g[i-1]$, so we can keep two rolling variables and reduce the extra space to $O(1)$.
 
 <!-- tabs:start -->
 


### PR DESCRIPTION
## Summary
- Split the O(1) extra-space rolling DP out of Method 1 into Method 2
- Keep the existing implementations; README structure now matches `Solution` / `Solution2`

## Test plan
- [ ] Confirm each method section matches the corresponding solution files

Made with [Cursor](https://cursor.com)