### PR TITLE
docs: split problem 2809 1D DP into method 2

### DIFF
--- a/solution/2800-2899/2809.Minimum Time to Make Array Sum At Most x/README.md
+++ b/solution/2800-2899/2809.Minimum Time to Make Array Sum At Most x/README.md
@@ -264,7 +264,13 @@ function minimumTime(nums1: number[], nums2: number[], x: number): number {
 
 <!-- tabs:end -->
 
-我们注意到，状态 $f[i][j]$ 只与 $f[i-1][j]$ 和 $f[i-1][j-1]$ 有关，因此我们可以优化掉第一维，将空间复杂度降低到 $O(n)$。
+<!-- solution:end -->
+
+<!-- solution:start -->
+
+### 方法二：动态规划优化
+
+我们注意到 $f[i][j]$ 只与 $f[i-1][j]$ 和 $f[i-1][j-1]$ 有关，因此可以去掉第一维并从大到小枚举 $j$，将空间复杂度降低到 $O(n)$。
 
 <!-- tabs:start -->
 

--- a/solution/2800-2899/2809.Minimum Time to Make Array Sum At Most x/README_EN.md
+++ b/solution/2800-2899/2809.Minimum Time to Make Array Sum At Most x/README_EN.md
@@ -263,7 +263,13 @@ function minimumTime(nums1: number[], nums2: number[], x: number): number {
 
 <!-- tabs:end -->
 
-We notice that the state $f[i][j]$ is only related to $f[i-1][j]$ and $f[i-1][j-1]$, so we can optimize the first dimension and reduce the space complexity to $O(n)$.
+<!-- solution:end -->
+
+<!-- solution:start -->
+
+### Solution 2: Optimized Dynamic Programming
+
+$f[i][j]$ only depends on $f[i-1][j]$ and $f[i-1][j-1]$, so we can drop the first dimension and enumerate $j$ from large to small, reducing the space complexity to $O(n)$.
 
 <!-- tabs:start -->
 


### PR DESCRIPTION
## Summary
- Split the 1D rolling DP out of Method 1 into Method 2
- Keep the existing implementations; README structure now matches `Solution` / `Solution2`

## Test plan
- [ ] Confirm Method 1 is 2D `f[i][j]` and Method 2 is 1D `f[j]`

Made with [Cursor](https://cursor.com)