### PR TITLE
docs: document BFS method for problem 947

### DIFF
--- a/solution/0900-0999/0947.Most Stones Removed with Same Row or Column/README.md
+++ b/solution/0900-0999/0947.Most Stones Removed with Same Row or Column/README.md
@@ -630,7 +630,7 @@ function removeStones(stones: number[][]): number {
         }
     }
 
-    const dfs = (i: number) => {
+    const bfs = (i: number) => {
         const seen = new Set<number>();
 
         let q = [i];
@@ -651,7 +651,7 @@ function removeStones(stones: number[][]): number {
     const set = new Set(Array.from({ length: n }, (_, i) => i));
     let ans = n;
     for (const i of set) {
-        dfs(i);
+        bfs(i);
         ans--;
     }
 
@@ -676,7 +676,7 @@ function removeStones(stones) {
         }
     }
 
-    const dfs = i => {
+    const bfs = i => {
         const seen = new Set();
 
         let q = [i];
@@ -697,7 +697,7 @@ function removeStones(stones) {
     const set = new Set(Array.from({ length: n }, (_, i) => i));
     let ans = n;
     for (const i of set) {
-        dfs(i);
+        bfs(i);
         ans--;
     }
 

--- a/solution/0900-0999/0947.Most Stones Removed with Same Row or Column/README.md
+++ b/solution/0900-0999/0947.Most Stones Removed with Same Row or Column/README.md
@@ -599,11 +599,17 @@ function removeStones(stones: number[][]): number {
 
 <!-- tabs:end -->
 
-<!--- solution:end --->
+<!-- solution:end -->
 
 <!-- solution:start -->
 
-### Solution 3: DFS
+### 方法三：广度优先搜索
+
+将同行或同列的石头连边。每个连通分量最后只能留下一块石头，因此答案为石头总数减去连通分量个数。
+
+从每个尚未访问的石头出发做广度优先搜索，标记它所在的连通块。
+
+时间复杂度 $O(n^2)$，空间复杂度 $O(n^2)$。其中 $n$ 是石头的数量。
 
 <!-- tabs:start -->
 

--- a/solution/0900-0999/0947.Most Stones Removed with Same Row or Column/README_EN.md
+++ b/solution/0900-0999/0947.Most Stones Removed with Same Row or Column/README_EN.md
@@ -632,7 +632,7 @@ function removeStones(stones: number[][]): number {
         }
     }
 
-    const dfs = (i: number) => {
+    const bfs = (i: number) => {
         const seen = new Set<number>();
 
         let q = [i];
@@ -653,7 +653,7 @@ function removeStones(stones: number[][]): number {
     const set = new Set(Array.from({ length: n }, (_, i) => i));
     let ans = n;
     for (const i of set) {
-        dfs(i);
+        bfs(i);
         ans--;
     }
 
@@ -678,7 +678,7 @@ function removeStones(stones) {
         }
     }
 
-    const dfs = i => {
+    const bfs = i => {
         const seen = new Set();
 
         let q = [i];
@@ -699,7 +699,7 @@ function removeStones(stones) {
     const set = new Set(Array.from({ length: n }, (_, i) => i));
     let ans = n;
     for (const i of set) {
-        dfs(i);
+        bfs(i);
         ans--;
     }
 

--- a/solution/0900-0999/0947.Most Stones Removed with Same Row or Column/README_EN.md
+++ b/solution/0900-0999/0947.Most Stones Removed with Same Row or Column/README_EN.md
@@ -605,7 +605,13 @@ function removeStones(stones: number[][]): number {
 
 <!-- solution:start -->
 
-### Solution 3: DFS
+### Solution 3: Breadth-First Search
+
+Connect stones that share a row or a column. Each connected component can keep only one stone, so the answer is the number of stones minus the number of components.
+
+Start a BFS from every unvisited stone to mark its component.
+
+The time complexity is $O(n^2)$ and the space complexity is $O(n^2)$, where $n$ is the number of stones.
 
 <!-- tabs:start -->
 

--- a/solution/0900-0999/0947.Most Stones Removed with Same Row or Column/Solution3.js
+++ b/solution/0900-0999/0947.Most Stones Removed with Same Row or Column/Solution3.js
@@ -12,7 +12,7 @@ function removeStones(stones) {
         }
     }
 
-    const dfs = i => {
+    const bfs = i => {
         const seen = new Set();
 
         let q = [i];
@@ -33,7 +33,7 @@ function removeStones(stones) {
     const set = new Set(Array.from({ length: n }, (_, i) => i));
     let ans = n;
     for (const i of set) {
-        dfs(i);
+        bfs(i);
         ans--;
     }
 

--- a/solution/0900-0999/0947.Most Stones Removed with Same Row or Column/Solution3.ts
+++ b/solution/0900-0999/0947.Most Stones Removed with Same Row or Column/Solution3.ts
@@ -12,7 +12,7 @@ function removeStones(stones: number[][]): number {
         }
     }
 
-    const dfs = (i: number) => {
+    const bfs = (i: number) => {
         const seen = new Set<number>();
 
         let q = [i];
@@ -33,7 +33,7 @@ function removeStones(stones: number[][]): number {
     const set = new Set(Array.from({ length: n }, (_, i) => i));
     let ans = n;
     for (const i of set) {
-        dfs(i);
+        bfs(i);
         ans--;
     }
 


### PR DESCRIPTION
## Summary
- Rename the English `Solution 3: DFS` heading in the Chinese write-up to `方法三：广度优先搜索`
- The existing TS/JS code walks components with a queue, so the title is BFS rather than DFS
- Answer is `n - components` after connecting stones that share a row or column

## Test plan
- [ ] `[[0,0],[0,1],[1,0],[1,2],[2,1],[2,2]]` = 5
- [ ] `[[0,0],[0,2],[1,1],[2,0],[2,2]]` = 3

Made with [Cursor](https://cursor.com)