### PR TITLE
docs: drop empty method 2 stub for problem 2231

### DIFF
--- a/solution/2200-2299/2231.Largest Number After Digit Swaps by Parity/README.md
+++ b/solution/2200-2299/2231.Largest Number After Digit Swaps by Parity/README.md
@@ -194,10 +194,4 @@ function largestInteger(num: number): number {
 
 <!-- solution:end -->
 
-<!-- solution:start -->
-
-### 方法二：分组 + 排序
-
-<!-- solution:end -->
-
 <!-- problem:end -->


### PR DESCRIPTION
## Summary
- Method 2 was only a heading (`分组 + 排序`) with no code and no `Solution2.*`
- Keep the existing counting solution as the only method

## Test plan
- [ ] Method 1 counting write-up and tabs are unchanged

Made with [Cursor](https://cursor.com)