### PR TITLE
docs: drop empty KMP stub for problem 28

### DIFF
--- a/solution/0000-0099/0028.Find the Index of the First Occurrence in a String/README.md
+++ b/solution/0000-0099/0028.Find the Index of the First Occurrence in a String/README.md
@@ -386,12 +386,4 @@ function strStr(haystack: string, needle: string): number {
 
 <!-- solution:end -->
 
-<!-- solution:start -->
-
-### 方法三：KMP 字符串匹配算法
-
-假设字符串 `haystack` 长度为 $n$，字符串 `needle` 长度为 $m$，则时间复杂度为 $O(n+m)$，空间复杂度 $O(m)$。
-
-<!-- solution:end -->
-
 <!-- problem:end -->

--- a/solution/0000-0099/0028.Find the Index of the First Occurrence in a String/README_EN.md
+++ b/solution/0000-0099/0028.Find the Index of the First Occurrence in a String/README_EN.md
@@ -387,12 +387,4 @@ function strStr(haystack: string, needle: string): number {
 
 <!-- solution:end -->
 
-<!-- solution:start -->
-
-### Solution 3: KMP String Matching Algorithm
-
-Assuming the length of the string `haystack` is $n$ and the length of the string `needle` is $m$, the time complexity is $O(n+m)$, and the space complexity is $O(m)$.
-
-<!-- solution:end -->
-
 <!-- problem:end -->


### PR DESCRIPTION
## Summary
- Method 3 was a KMP heading plus complexity, with no code and no `Solution3.*`
- Keep traversal and Rabin-Karp; do not invent an unused KMP implementation

## Test plan
- [ ] Method 1 and method 2 tabs are unchanged

Made with [Cursor](https://cursor.com)