### PR TITLE
docs: add missing tabs marker for problem 3202

### DIFF
--- a/solution/3200-3299/3202.Find the Maximum Length of Valid Subsequence II/README.md
+++ b/solution/3200-3299/3202.Find the Maximum Length of Valid Subsequence II/README.md
@@ -81,6 +81,8 @@ tags:
 
 时间复杂度 $O(n \times k)$，空间复杂度 $O(k^2)$。其中 $n$ 为数组 $\textit{nums}$ 的长度，而 $k$ 为给定的正整数。
 
+<!-- tabs:start -->
+
 #### Python3
 
 ```python


### PR DESCRIPTION
## Summary
- The Chinese write-up had `tabs:end` without `tabs:start`
- Add the missing marker so language tabs match the English page

## Test plan
- [ ] Method 1 language tabs render correctly

Made with [Cursor](https://cursor.com)