### PR TITLE
docs: add missing tabs marker for problem 3661

### DIFF
--- a/solution/3600-3699/3661.Maximum Walls Destroyed by Robots/README.md
+++ b/solution/3600-3699/3661.Maximum Walls Destroyed by Robots/README.md
@@ -128,6 +128,8 @@ tags:
 
 时间复杂度 $O(n \times \log n + m \times \log m)$，空间复杂度 $O(n)$。其中 $n$ 和 $m$ 分别是机器人和墙壁的数量。
 
+<!-- tabs:start -->
+
 #### Python3
 
 ```python


### PR DESCRIPTION
## Summary
- The Chinese write-up had `tabs:end` without `tabs:start`
- Add the missing marker so language tabs match the English page

## Test plan
- [ ] Method 1 language tabs render correctly

Made with [Cursor](https://cursor.com)