### PR TITLE
docs: drop extra tabs marker for problem 1470

### DIFF
--- a/solution/1400-1499/1470.Shuffle the Array/README.md
+++ b/solution/1400-1499/1470.Shuffle the Array/README.md
@@ -169,8 +169,4 @@ int* shuffle(int* nums, int numsSize, int n, int* returnSize) {
 
 <!-- solution:end -->
 
-<!-- tabs:end -->
-
-<!-- solution:end -->
-
 <!-- problem:end -->


### PR DESCRIPTION
## Summary
- Remove a duplicate `tabs:end` / `solution:end` pair after the only method

## Test plan
- [ ] The page still closes with a single solution block then `problem:end`

Made with [Cursor](https://cursor.com)