### PR TITLE
docs: title group-permutation search for problem 1815

### DIFF
--- a/solution/1800-1899/1815.Maximum Number of Groups Getting Fresh Donuts/README.md
+++ b/solution/1800-1899/1815.Maximum Number of Groups Getting Fresh Donuts/README.md
@@ -226,7 +226,13 @@ func maxHappyGroups(batchSize int, groups []int) (ans int) {
 
 <!-- solution:start -->
 
-### 方法二
+### 方法二：记忆化搜索（按组排列）
+
+先把人数为 $batchSize$ 整数倍的组贪心计入答案，再只保留其余组对 $batchSize$ 取模后的余数。
+
+用二进制状态表示哪些组已经安排，设计函数 $dfs(state, x)$：当前已安排集合为 $state$、前缀余数为 $x$ 时，还能再让多少组开心。枚举尚未安排的组，对相同余数去重后递归；若 $x = 0$，当前这一步会让一组开心。
+
+时间复杂度 $O(2^m \times m)$，空间复杂度 $O(2^m)$。其中 $m$ 为余数非 $0$ 的组数。
 
 <!-- tabs:start -->
 

--- a/solution/1800-1899/1815.Maximum Number of Groups Getting Fresh Donuts/README_EN.md
+++ b/solution/1800-1899/1815.Maximum Number of Groups Getting Fresh Donuts/README_EN.md
@@ -224,7 +224,13 @@ func maxHappyGroups(batchSize int, groups []int) (ans int) {
 
 <!-- solution:start -->
 
-### Solution 2
+### Solution 2: Memorized Search (Group Permutation)
+
+First count the groups whose sizes are multiples of $batchSize$, then keep only the remainders of the other groups.
+
+Use a bitmask for the set of placed groups, and let $dfs(state, x)$ be the number of additional happy groups when the placed set is $state$ and the current prefix remainder is $x$. Enumerate unused groups, skip duplicate remainders, and recurse. If $x = 0$, the current step makes one group happy.
+
+The time complexity is $O(2^m \times m)$, and the space complexity is $O(2^m)$, where $m$ is the number of groups whose remainder is nonzero.
 
 <!-- tabs:start -->
 


### PR DESCRIPTION
## Summary
- Title untitled method 2 as memorized search over individual group permutations
- Document the remainder-filter + bitmask DFS, which is different from method 1's packed remainder counts

## Test plan
- [ ] Sample `batchSize = 3, groups = [1,2,3,4,5,6]` still returns `4`
- [ ] Method 1 stays remainder-bucket state; method 2 is per-group bitmask

Made with [Cursor](https://cursor.com)