### PR TITLE
docs: fix tabs marker order for problem 1980

### DIFF
--- a/solution/1900-1999/1980.Find Unique Binary String/README.md
+++ b/solution/1900-1999/1980.Find Unique Binary String/README.md
@@ -325,8 +325,8 @@ public class Solution {
 }
 ```
 
-<!-- solution:end -->
-
 <!-- tabs:end -->
+
+<!-- solution:end -->
 
 <!-- problem:end -->

--- a/solution/1900-1999/1980.Find Unique Binary String/README_EN.md
+++ b/solution/1900-1999/1980.Find Unique Binary String/README_EN.md
@@ -324,8 +324,8 @@ public class Solution {
 }
 ```
 
-<!-- solution:end -->
-
 <!-- tabs:end -->
+
+<!-- solution:end -->
 
 <!-- problem:end -->


### PR DESCRIPTION
## Summary
- Close method 2 tabs before `solution:end`
- Remove the orphaned `tabs:end` that sat after the solution block

## Test plan
- [ ] Sample `nums = ["01","10"]` still maps to `11`
- [ ] Method 2 has `tabs:start` / `tabs:end` wrapping only its language tabs

Made with [Cursor](https://cursor.com)