### PR TITLE
docs: close solution markers for problem 22

### DIFF
--- a/solution/0000-0099/0022.Generate Parentheses/README.md
+++ b/solution/0000-0099/0022.Generate Parentheses/README.md
@@ -288,6 +288,6 @@ class Solution {
 
 <!-- tabs:end -->
 
-<!-- solution:start -->
+<!-- solution:end -->
 
 <!-- problem:end -->


### PR DESCRIPTION
## Summary
- Replace the orphan `<!-- solution:start -->` after method 1 with `<!-- solution:end -->` so the Chinese README matches the English file and the site template.

## Test plan
- [ ] Confirm problem 22 Chinese page renders one closed method and no empty second method block
- [ ] Sample: `n = 3` → `["((()))","(()())","(())()","()(())","()()()"]`

Made with [Cursor](https://cursor.com)