### PR TITLE
ci: use the new doocs bot commit email

### DIFF
--- a/.github/workflows/prettier-write.yml
+++ b/.github/workflows/prettier-write.yml
@@ -70,4 +70,4 @@ jobs:
         with:
           commit_message: "style: format code and docs with prettier"
           commit_user_name: idoocs
-          commit_user_email: doocs-bot@outlook.com
+          commit_user_email: botdoocs@gmail.com

--- a/.github/workflows/update-starcharts.yml
+++ b/.github/workflows/update-starcharts.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   update:
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: MaoLongLong/actions-starcharts@8a02621f35e876183d7101b583133403e0c11c02 # main
         with:
-          github_token: ${{ secrets.DOOCS_BOT_ACTION_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           svg_path: images/starcharts.svg
           commit_message: "chore: auto update starcharts"
           stars_change: ${{ secrets.STARS_CHANGE }}

--- a/.github/workflows/update-starcharts.yml
+++ b/.github/workflows/update-starcharts.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   update:
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: MaoLongLong/actions-starcharts@8a02621f35e876183d7101b583133403e0c11c02 # main
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.DOOCS_BOT_ACTION_TOKEN }}
           svg_path: images/starcharts.svg
           commit_message: "chore: auto update starcharts"
           stars_change: ${{ secrets.STARS_CHANGE }}


### PR DESCRIPTION
﻿## Summary
- Keep `update-starcharts` on the org-level `DOOCS_BOT_ACTION_TOKEN` (already rotated).
- Point `prettier-write` commits at the new bot email `botdoocs@gmail.com`.

## Test plan
- [ ] After merge, a same-repo markdown PR should still get Prettier auto-commits as `idoocs <botdoocs@gmail.com>`
- [ ] Run `update-starcharts` via workflow_dispatch and confirm it no longer fails with 401
