### PR TITLE
feat: render thinking blocks as Material admonitions

### DIFF
--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           python-version: "3.12"
       - name: Run docs hook tests
-        run: python -m unittest tests.test_stay_on_page tests.test_conditional_mathjax -v
+        run: python -m unittest tests.test_stay_on_page tests.test_conditional_mathjax tests.test_thinking_block -v

--- a/docs-en/stylesheets/extra.css
+++ b/docs-en/stylesheets/extra.css
@@ -1,6 +1,7 @@
 :root {
     --example-block-bg: #f5f5f5;
     --pre-bg: #f5f5f5;
+    --md-admonition-icon--thinking: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9 22a1 1 0 0 1-1-1v-1h8v1a1 1 0 0 1-1 1zm3-20a7 7 0 0 1 4 12.74V17a1 1 0 0 1-1 1H9a1 1 0 0 1-1-1v-2.26A7 7 0 0 1 12 2m0 2a5 5 0 0 0-3.16 8.9l.16.13V16h6v-2.97l.16-.13A5 5 0 0 0 12 4Z"/></svg>');
 }
 
 [data-md-color-scheme="default"] {
@@ -34,4 +35,19 @@
     padding: .3em;
     background-color: var(--pre-bg);
     border-radius: .1rem;
+}
+
+.md-typeset .admonition.thinking,
+.md-typeset details.thinking {
+    border-color: #5c6bc0;
+}
+.md-typeset .thinking > .admonition-title,
+.md-typeset .thinking > summary {
+    background-color: rgba(92, 107, 192, 0.1);
+}
+.md-typeset .thinking > .admonition-title::before,
+.md-typeset .thinking > summary::before {
+    background-color: #5c6bc0;
+    -webkit-mask-image: var(--md-admonition-icon--thinking);
+    mask-image: var(--md-admonition-icon--thinking);
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,6 +1,7 @@
 :root {
     --example-block-bg: #f5f5f5;
     --pre-bg: #f5f5f5;
+    --md-admonition-icon--thinking: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9 22a1 1 0 0 1-1-1v-1h8v1a1 1 0 0 1-1 1zm3-20a7 7 0 0 1 4 12.74V17a1 1 0 0 1-1 1H9a1 1 0 0 1-1-1v-2.26A7 7 0 0 1 12 2m0 2a5 5 0 0 0-3.16 8.9l.16.13V16h6v-2.97l.16-.13A5 5 0 0 0 12 4Z"/></svg>');
 }
 
 [data-md-color-scheme="default"] {
@@ -34,4 +35,19 @@
     padding: .3em;
     background-color: var(--pre-bg);
     border-radius: .1rem;
+}
+
+.md-typeset .admonition.thinking,
+.md-typeset details.thinking {
+    border-color: #5c6bc0;
+}
+.md-typeset .thinking > .admonition-title,
+.md-typeset .thinking > summary {
+    background-color: rgba(92, 107, 192, 0.1);
+}
+.md-typeset .thinking > .admonition-title::before,
+.md-typeset .thinking > summary::before {
+    background-color: #5c6bc0;
+    -webkit-mask-image: var(--md-admonition-icon--thinking);
+    mask-image: var(--md-admonition-icon--thinking);
 }

--- a/hooks/thinking_block.py
+++ b/hooks/thinking_block.py
@@ -1,0 +1,45 @@
+"""Turn <!-- thinking --> blockquotes into a Material admonition."""
+
+import re
+
+BLOCK_RE = re.compile(
+    r"<!-- thinking:start -->\s*(.*?)<!-- thinking:end -->",
+    re.DOTALL,
+)
+
+
+def _strip_quote(body: str) -> tuple[str, str]:
+    lines = body.strip().splitlines()
+    title = "思考"
+    content: list[str] = []
+    for line in lines:
+        if line.startswith("> "):
+            raw = line[2:]
+        elif line.strip() == ">":
+            raw = ""
+        else:
+            raw = line
+        if not content and raw.strip() in ("**思考**", "**Thinking**"):
+            title = "思考" if "思考" in raw else "Thinking"
+            continue
+        content.append(raw)
+    while content and not content[0].strip():
+        content.pop(0)
+    while content and not content[-1].strip():
+        content.pop()
+    return title, "\n".join(content)
+
+
+def convert_thinking_blocks(markdown: str) -> str:
+    def repl(match: re.Match[str]) -> str:
+        title, body = _strip_quote(match.group(1))
+        indented = "\n".join(
+            f"    {line}" if line.strip() else "" for line in body.splitlines()
+        )
+        return f'!!! thinking "{title}"\n\n{indented}\n'
+
+    return BLOCK_RE.sub(repl, markdown)
+
+
+def on_page_markdown(markdown, page, config, files):
+    return convert_thinking_blocks(markdown)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ plugins:
 hooks:
   - hooks/edit_url.py
   - hooks/committer.py
+  - hooks/thinking_block.py
   - hooks/fix_markdown_block.py
   - hooks/ext_info.py
   - hooks/tags.py

--- a/tests/test_thinking_block.py
+++ b/tests/test_thinking_block.py
@@ -1,0 +1,73 @@
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "hooks"))
+import thinking_block as tb  # noqa: E402
+
+ZH = """### 方法一：哈希表
+
+<!-- thinking:start -->
+
+> **思考**
+>
+> 若枚举所有数对，时间复杂度为 $O(n^2)$。
+>
+> 对当前元素 $x$，先查询再插入。
+
+<!-- thinking:end -->
+
+我们可以使用一个哈希表。
+"""
+
+EN = """### Solution 1: Hash Table
+
+<!-- thinking:start -->
+
+> **Thinking**
+>
+> The first idea is a nested loop.
+
+<!-- thinking:end -->
+
+We can use a hash table.
+"""
+
+
+class ThinkingBlockTest(unittest.TestCase):
+    def test_converts_chinese_blockquote(self):
+        out = tb.convert_thinking_blocks(ZH)
+        self.assertIn('!!! thinking "思考"', out)
+        self.assertIn("    若枚举所有数对，时间复杂度为 $O(n^2)$。", out)
+        self.assertIn("    对当前元素 $x$，先查询再插入。", out)
+        self.assertNotIn("<!-- thinking:start -->", out)
+        self.assertNotIn("> **思考**", out)
+        self.assertIn("我们可以使用一个哈希表。", out)
+
+    def test_converts_english_blockquote(self):
+        out = tb.convert_thinking_blocks(EN)
+        self.assertIn('!!! thinking "Thinking"', out)
+        self.assertIn("    The first idea is a nested loop.", out)
+        self.assertNotIn("> **Thinking**", out)
+        self.assertIn("We can use a hash table.", out)
+
+    def test_converts_multiple_blocks(self):
+        out = tb.convert_thinking_blocks(ZH + "\n" + EN)
+        self.assertEqual(out.count("!!! thinking"), 2)
+        self.assertIn('!!! thinking "思考"', out)
+        self.assertIn('!!! thinking "Thinking"', out)
+
+    def test_leaves_pages_without_markers(self):
+        src = "### 方法一\n\n直接写解法。\n"
+        self.assertEqual(tb.convert_thinking_blocks(src), src)
+
+    def test_on_page_markdown_delegates(self):
+        self.assertEqual(
+            tb.on_page_markdown(EN, None, None, None),
+            tb.convert_thinking_blocks(EN),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Convert `<!-- thinking -->` blockquotes into a Material `thinking` admonition so the walkthrough is one titled box, not a plain quote.
- Add indigo/lightbulb styles in zh and en `extra.css`, and hook the converter in `mkdocs.yml`.
- Cover the conversion in `tests/test_thinking_block.py` and run it from `docs-test`.

Pairs with the problem-source walkthroughs in https://github.com/doocs/leetcode/pull/5568.

## Test plan
- [ ] `python -m unittest tests.test_thinking_block -v`
- [ ] After deploy (or local overlay + `mkdocs serve`), open a 1–99 problem such as `/lc/15/` and confirm the **思考** / **Thinking** box sits between the method heading and the formal write-up
- [ ] Confirm a page without thinking markers is unchanged
- [ ] Check light and dark palettes for the indigo border and icon