### PR TITLE
fix: use ### Solution headings on English thinking pages

### DIFF
--- a/solution/0200-0299/0208.Implement Trie (Prefix Tree)/README_EN.md
+++ b/solution/0200-0299/0208.Implement Trie (Prefix Tree)/README_EN.md
@@ -64,7 +64,7 @@ trie.search(&quot;app&quot;);     // return True
 
 <!-- solution:start -->
 
-## Solution 1: Trie (Prefix Tree)
+### Solution 1: Trie (Prefix Tree)
 
 <!-- thinking:start -->
 

--- a/solution/0200-0299/0257.Binary Tree Paths/README_EN.md
+++ b/solution/0200-0299/0257.Binary Tree Paths/README_EN.md
@@ -52,7 +52,7 @@ tags:
 
 <!-- solution:start -->
 
-## Solution 1: DFS
+### Solution 1: DFS
 
 <!-- thinking:start -->
 

--- a/solution/0800-0899/0845.Longest Mountain in Array/README_EN.md
+++ b/solution/0800-0899/0845.Longest Mountain in Array/README_EN.md
@@ -71,7 +71,7 @@ tags:
 
 <!-- solution:start -->
 
-## Solution 1: Preprocessing + Enumeration
+### Solution 1: Preprocessing + Enumeration
 
 <!-- thinking:start -->
 
@@ -227,7 +227,7 @@ function longestMountain(arr: number[]): number {
 
 <!-- solution:start -->
 
-## Solution 2: One Pass (Enumerate Left Base of Mountain)
+### Solution 2: One Pass (Enumerate Left Base of Mountain)
 
 <!-- thinking:start -->
 


### PR DESCRIPTION
## Summary
- Change `## Solution N` to `### Solution N` on three English READMEs that already have Thinking blocks.
- `scripts/check_thinking.py` only counts `### 方法|Solution|Approach|Method` headings, so #5618 failed thinking-check when it touched these files.

## Type
- [x] Other

## Checklist
- [x] Headings now match the Chinese `### 方法` level
- [x] `python scripts/check_thinking.py` passes on the three files

## Test plan
- [x] Local thinking-check on the three `README_EN.md` files
- [ ] CI thinking-check on this PR