### PR TITLE
ci: publish Gitee pages outside the deploy-site lock

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -272,49 +272,24 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v5
 
-  publish-gitee:
+  dispatch-publish-gitee:
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      actions: read
+      actions: write
     steps:
-      - name: Download Chinese site
-        uses: actions/download-artifact@v8
-        with:
-          name: site-zh
-          path: site
-
-      - name: Download English site
-        uses: actions/download-artifact@v8
-        with:
-          name: site-en
-          path: site/en
-
-      - name: Push orphan pages branch to Gitee
+      - name: Dispatch publish-gitee
         env:
-          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+          SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if [ -z "${GITEE_TOKEN}" ]; then
-            echo "GITEE_TOKEN secret is not set."
-            exit 1
-          fi
-          cd site
-          touch .nojekyll
-          git init
-          git checkout --orphan pages
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "deploy: ${GITHUB_SHA}"
-
-          ASKPASS="$(mktemp)"
-          trap 'rm -f "$ASKPASS"' EXIT
-          printf '%s\n' '#!/bin/sh' 'echo "$GITEE_TOKEN"' > "$ASKPASS"
-          chmod 700 "$ASKPASS"
-          GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0 \
-            git push -f https://oauth2@gitee.com/Doocs/leetcode.git HEAD:pages
+          gh workflow run publish-gitee.yml --ref "${REF_NAME}" --repo "${REPO}" \
+            -f source_run_id="${RUN_ID}" \
+            -f source_sha="${SHA}"
 
   deploy-cloudflare:
     needs: build

--- a/.github/workflows/publish-gitee.yml
+++ b/.github/workflows/publish-gitee.yml
@@ -1,0 +1,69 @@
+name: publish-gitee
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: deploy.yml run id that uploaded site-zh and site-en
+        required: true
+        type: string
+      source_sha:
+        description: commit SHA recorded in the Gitee pages commit message
+        required: false
+        type: string
+
+concurrency:
+  group: publish-gitee
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  publish-gitee:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Chinese site
+        uses: actions/download-artifact@v8
+        with:
+          name: site-zh
+          path: site
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+
+      - name: Download English site
+        uses: actions/download-artifact@v8
+        with:
+          name: site-en
+          path: site/en
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.source_run_id }}
+
+      - name: Push orphan pages branch to Gitee
+        env:
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+          SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GITEE_TOKEN}" ]; then
+            echo "GITEE_TOKEN secret is not set."
+            exit 1
+          fi
+          cd site
+          touch .nojekyll
+          git init
+          git checkout --orphan pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "deploy: ${SOURCE_SHA}"
+
+          ASKPASS="$(mktemp)"
+          trap 'rm -f "$ASKPASS"' EXIT
+          printf '%s\n' '#!/bin/sh' 'echo "$GITEE_TOKEN"' > "$ASKPASS"
+          chmod 700 "$ASKPASS"
+          GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0 \
+            git push -f https://oauth2@gitee.com/Doocs/leetcode.git HEAD:pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ This is [doocs/leetcode](https://github.com/doocs/leetcode) — a large collecti
 - **`main`** — problem sources, lint tooling, and deploy workflows.
 - **`docs`** — MkDocs site engine only (`build_site.py`, `mkdocs.yml`, `hooks/`, `overrides/`). Problem pages are generated at deploy time from `main`.
 
-Deploy checks out both branches, overlays a whitelist from `docs` onto `main`, runs `python3 build_site.py`, then builds zh/en in parallel. Content pushes on `main` (problem trees, `worker.js`, and `wrangler.jsonc`) go through `deploy-request.yml` (about 90s quiet period, then `gh workflow run deploy.yml`). Pushes to `docs` use `.github/workflows/trigger-deploy.yml` on the `docs` branch the same way. A started `deploy.yml` run is not cancelled.
+Deploy checks out both branches, overlays a whitelist from `docs` onto `main`, runs `python3 build_site.py`, then builds zh/en in parallel. Content pushes on `main` (problem trees, `worker.js`, and `wrangler.jsonc`) go through `deploy-request.yml` (about 90s quiet period, then `gh workflow run deploy.yml`). Pushes to `docs` use `.github/workflows/trigger-deploy.yml` on the `docs` branch the same way. A started `deploy.yml` run is not cancelled. Gitee Pages publish is a separate `publish-gitee.yml` workflow dispatched after the site build, so a slow Gitee push does not hold the `deploy-site` concurrency group.
 
 Dependabot updates npm, GitHub Actions, and pip on `main`, and pip on `docs`.
 


### PR DESCRIPTION
## Summary

Split Gitee Pages publish into its own workflow so a slow Gitee force-push no longer holds the `deploy-site` concurrency group and queues later deploys.

- `deploy.yml` only dispatches `publish-gitee.yml` after the site build
- Gitee publish downloads `site-zh` / `site-en` from that deploy run and uses its own concurrency group

## Type

- [x] Other

## Checklist

For new or updated solutions:

- [ ] `README.md` / `README_EN.md` follow `solution/template.md`
- [ ] If a Thinking block is added, it sits after the method heading, is non-empty, and matches the code in the repo (naive idea vs constraints, bottleneck, key observation, why this method). Thinking is optional.
- [ ] All languages implement the same algorithm; unrelated `Solution.*` files and code tabs are unchanged
- [ ] Code is formatted as described in `AGENTS.md`

## Test plan

- [ ] Confirm a `deploy.yml` run finishes after Pages / Cloudflare even while Gitee is still pushing
- [ ] Confirm a second deploy can start while `publish-gitee` is still running
- [ ] Confirm `publish-gitee` downloads artifacts from the source deploy run and updates the Gitee `pages` branch

Made with [Cursor](https://cursor.com)