### PR TITLE
ci: dispatch Gitee branch sync after docs pushes

### DIFF
--- a/.github/workflows/trigger-sync-gitee.yml
+++ b/.github/workflows/trigger-sync-gitee.yml
@@ -1,0 +1,25 @@
+name: trigger-sync-gitee
+
+on:
+  push:
+    branches:
+      - docs
+
+concurrency:
+  group: trigger-sync-gitee
+  cancel-in-progress: true
+
+jobs:
+  trigger:
+    if: github.repository == 'doocs/leetcode'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch sync-gitee for docs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh workflow run sync-gitee.yml --ref main --repo "${REPO}" -f branch=docs


### PR DESCRIPTION
## Summary

Add `trigger-sync-gitee.yml` on the `docs` branch. A push to `docs` dispatches `sync-gitee.yml` on `main` with `branch=docs`, so Gitee `docs` stays in sync.

Depends on https://github.com/doocs/leetcode/pull/5625 landing on `main` first.

## Type

- [x] Other

## Checklist

For new or updated solutions:

- [ ] `README.md` / `README_EN.md` follow `solution/template.md`
- [ ] If a Thinking block is added, it sits after the method heading, is non-empty, and matches the code in the repo (naive idea vs constraints, bottleneck, key observation, why this method). Thinking is optional.
- [ ] All languages implement the same algorithm; unrelated `Solution.*` files and code tabs are unchanged
- [ ] Code is formatted as described in `AGENTS.md`

## Test plan

- [ ] Merge https://github.com/doocs/leetcode/pull/5625 first
- [ ] Merge this PR to `docs`
- [ ] Push to `docs` and confirm `sync-gitee` runs with `branch=docs`
- [ ] Confirm Gitee `docs` matches the GitHub SHA